### PR TITLE
Add .git-blame-ignore-revs file containing format commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# scalafmt
+cceccdcd0e48db13f5e09ee773353b6fd2cd851d


### PR DESCRIPTION
Similar to pekko core, adds a `.git-blame-ignore-revs` which contains the hashes for the previous scalafmt commits.