### PR TITLE
Add github workflow to check scala code is formatted

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,24 @@
+name: Scalafmt
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v2
+        with:
+          version: '3.6.1'
+          arguments: '--list --mode diff-ref=origin/main'

--- a/build.sbt
+++ b/build.sbt
@@ -38,14 +38,6 @@ TaskKey[Unit]("verifyCodeFmt") := {
     throw new MessageOnlyException(
       "Unformatted Java code found. Please run 'javafmtAll' and commit the reformatted code")
   }
-  scalafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>
-    throw new MessageOnlyException(
-      "Unformatted Scala code found. Please run 'scalafmtAll' and commit the reformatted code")
-  }
-  (Compile / scalafmtSbtCheck).result.value.toEither.left.foreach { _ =>
-    throw new MessageOnlyException(
-      "Unformatted sbt code found. Please run 'scalafmtSbt' and commit the reformatted code")
-  }
 }
 
 addCommandAlias("verifyCodeStyle", "headerCheck; verifyCodeFmt")


### PR DESCRIPTION
Similar to pekko core, replaces the sbt scalafmt check with a github actions one. Also removes the `scalafmtCheckAll`/`scalafmtSbtCheck` check because it is now unnecessary (and it also doesn't play well with IDE's).