### PR TITLE
Fix README.md pointing to wrong CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Contributing
 
 Contributions are very welcome. If you have an idea on how to improve Pekko, don't hesitate to create an issue or submit a pull request.
 
-See [CONTRIBUTING.md](https://github.com/apache/incubator-pekko/blob/main/CONTRIBUTING.md) for details on the development workflow and how to create your pull request.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details on the development workflow and how to create your pull request.
 
 Caveat Emptor
 -------------


### PR DESCRIPTION
`CONTRIBUTING.md` is pointing to the wrong repo. Furthermore there is no need to do a direct link, you can just use a relative path (as a bonus this means the link will continue to work even when this repo path will be updated, which it will be when pekko leaves incubation).