### PR TITLE
Update scalafmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Check project is formatted
         uses: jrouly/scalafmt-native-action@v2
         with:
-          version: '3.6.1'
+          version: '3.7.1'
           arguments: '--list --mode diff-ref=origin/main'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version                                  = 3.6.1
+version                                  = 3.7.1
 runner.dialect                           = scala213
 project.git                              = true
 style                                    = defaultWithAlign

--- a/tests/src/test/scala/akka/kafka/internal/CommitCollectorStageSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommitCollectorStageSpec.scala
@@ -408,7 +408,9 @@ class CommitCollectorStageSpec(_system: ActorSystem)
   }
 
   private def streamProbesWithOffsetFactory(
-      committerSettings: CommitterSettings) = {
+      committerSettings: CommitterSettings): (TestPublisher.Probe[Committable],
+      Consumer.Control,
+      TestSubscriber.Probe[CommittableOffsetBatch], TestOffsetFactory) = {
     val (source, control, sink) = streamProbes(committerSettings)
     val factory = TestOffsetFactory(new TestBatchCommitter(committerSettings))
     (source, control, sink, factory)


### PR DESCRIPTION
Updates scalafmt and reverts removal of return function type in `streamProbesWithOffsetFactory`.

Resolves: https://github.com/apache/incubator-pekko-connectors-kafka/issues/14