### PR TITLE
Add Scala 2.12 to matrix

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -72,9 +72,9 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 
-      - name: Compile all code with fatal warnings for Java 11 and Scala 2.13
+      - name: Compile all code with fatal warnings for Java 11 and Scala 2.12/2.13
         # Run locally with: env CI=true sbt 'clean ; Test/compile ; It/compile'
-        run: sbt "; Test/compile; It/compile"
+        run: sbt "; +Test/compile; +It/compile"
 
   check-docs:
     name: Check Docs
@@ -112,6 +112,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - { java-version: 8,  scala-version: 2.12.17, sbt-opts: '' }
+          - { java-version: 11, scala-version: 2.12.17, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
           - { java-version: 8,  scala-version: 2.13.10, sbt-opts: '' }
           - { java-version: 11, scala-version: 2.13.10, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
     steps:

--- a/tests/src/test/scala/org/apache/pekko/kafka/TransactionsOps.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/TransactionsOps.scala
@@ -13,6 +13,7 @@
  */
 
 package org.apache.pekko.kafka
+
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.pekko
@@ -26,6 +27,7 @@ import pekko.stream.Materializer
 import pekko.stream.scaladsl.{ Flow, Sink, Source }
 import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.scaladsl.TestSink
+import pekko.util.ccompat._
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.{ ProducerConfig, ProducerRecord }
 import org.scalatest.TestSuite


### PR DESCRIPTION
When working on https://github.com/apache/incubator-pekko-connectors-kafka/pull/49 I forgot to add Scala 2.12 to build matrix