### PR TITLE
Add suppress warnings for unchecked conversions

### DIFF
--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/KafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/KafkaTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeAll;
  * of the test class with `@BeforeAll` and `@AfterAll` annotated methods called by the test
  * framework.
  */
+@SuppressWarnings("unchecked")
 public abstract class KafkaTest extends BaseKafkaTest {
 
   /**

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
@@ -30,6 +30,7 @@ import org.junit.Before;
  *
  * <p>The Testcontainers dependency has to be added explicitly.
  */
+@SuppressWarnings("unchecked")
 public abstract class TestcontainersKafkaJunit4Test extends KafkaJunit4Test {
 
   private static final KafkaTestkitTestcontainersSettings settings =

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaTest.java
@@ -31,6 +31,7 @@ import org.apache.pekko.stream.Materializer;
  *
  * <p>The Testcontainers dependency has to be added explicitly.
  */
+@SuppressWarnings("unchecked")
 public abstract class TestcontainersKafkaTest extends KafkaTest {
 
   public static final KafkaTestkitTestcontainersSettings settings =

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
+@SuppressWarnings("unchecked")
 public abstract class BaseKafkaTest extends KafkaTestKitClass {
 
   public static final int partition0 = 0;

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/KafkaJunit4Test.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/KafkaJunit4Test.java
@@ -22,6 +22,7 @@ import org.junit.After;
 import org.junit.Before;
 
 /** JUnit 4 base-class with some convenience for accessing a Kafka broker. */
+@SuppressWarnings("unchecked")
 public abstract class KafkaJunit4Test extends BaseKafkaTest {
 
   /**


### PR DESCRIPTION
When compiling this project you get these warnings

```
[warn] /Users/mdedetrich/github/incubator-pekko-connectors-kafka/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java:49:1: org$apache$pekko$kafka$testkit$internal$KafkaTestKit$$adminDefaults() in org.apache.pekko.kafka.testkit.internal.KafkaTestKitClass implements org$apache$pekko$kafka$testkit$internal$KafkaTestKit$$adminDefaults() in org.apache.pekko.kafka.testkit.internal.KafkaTestKit
[warn]   return type requires unchecked conversion from java.util.Map to java.util.Map<java.lang.String,java.lang.Object>
[warn] public abstract class BaseKafkaTest extends KafkaTestKitClass {
```

Adding `@SuppressWarnings("unchecked")` solves these issues. Note that this is not unusual for Java code within Pekko projects due to differences in variance from java to scala (i.e. see https://github.com/apache/incubator-pekko-http/blob/fa1cb9cbc2a22da6e507b3725e6fca7f3aab15da/http-core/src/main/java/org/apache/pekko/http/javadsl/model/ContentRange.java#L40 as an example)