### PR TITLE
Unwrap single string interpolation syntax

### DIFF
--- a/tests/src/it/scala/org/apache/pekko/kafka/PartitionedSourceFailoverSpec.scala
+++ b/tests/src/it/scala/org/apache/pekko/kafka/PartitionedSourceFailoverSpec.scala
@@ -72,7 +72,7 @@ class PartitionedSourceFailoverSpec
         .groupBy(partitions, _._1)
         .mapAsync(8) {
           case (tp, source) =>
-            log.info(s"Sub-source for ${tp}")
+            log.info(s"Sub-source for $tp")
             source
               .scan(0L)((c, _) => c + 1)
               .via(IntegrationTests.logReceivedMessages(tp)(log))


### PR DESCRIPTION
Unwraps single string interpolation i.e. `s"${something}"` into `s"$something"`. Make sure to do a rebase merge of this PR because I need to add its commit to `.git-blame-ignore-revs`