### PR TITLE
Add unwrap single string into .git-ignore-blame-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # scalafmt
 cceccdcd0e48db13f5e09ee773353b6fd2cd851d
+
+# manual
+63f2ae0e62b86d3fe1957825e344ca38721d3732


### PR DESCRIPTION
Adds the changes from https://github.com/apache/incubator-pekko-connectors-kafka/pull/76 into `.git-ignore-blame-revs`.