### PR TITLE
Use proper type for SemVerSpec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / resolvers ++= ResolverSettings.projectResolvers
 
 ThisBuild / apacheSonatypeProjectProfile := "pekko"
 sourceDistName := "incubating-pekko-connectors-kafka"
-ThisBuild / versionScheme := Some("semver-spec")
+ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 
 TaskKey[Unit]("verifyCodeFmt") := {
   javafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>


### PR DESCRIPTION
There is an actual proper type for `SemVerSpec` which is better than using a `String`.