### PR TITLE
protobuf 3.19.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
 
   lazy val testDependencies = Def.setting(Seq(
     "org.apache.pekko" %% "pekko-discovery" % pekkoVersion,
-    "com.google.protobuf" % "protobuf-java" % "3.19.1", // use the same version as in scalapb
+    "com.google.protobuf" % "protobuf-java" % "3.19.6", // use the same version as in scalapb
     ("io.confluent" % "kafka-avro-serializer" % confluentAvroSerializerVersion % Test).excludeAll(
       confluentLibsExclusionRules: _*),
     // See https://github.com/sbt/sbt/issues/3618#issuecomment-448951808


### PR DESCRIPTION
* just a test dependency
* still want to match what scalapb uses - https://mvnrepository.com/artifact/com.thesamet.scalapb/scalapb-runtime_3/0.11.13
* https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java (no CVEs for 3.19.6)
* patch upgrade (from 3.19.1)