### PR TITLE
Properly mask all sensitive fields in Consumer and Producer settings

### DIFF
--- a/core/src/main/scala/org/apache/pekko/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/ProducerSettings.scala
@@ -394,14 +394,13 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
       producerFactorySync)
 
   override def toString: String = {
-    val kafkaClients = properties.toSeq
-      .map {
-        case (key, _) if key.endsWith(".password") =>
-          key -> "[is set]"
-        case t => t
-      }
-      .sortBy(_._1)
-      .mkString(",")
+    val propertiesWithMandatoryKeys = properties ++ Map(
+      ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG -> keySerializerOpt.map(_.getClass).orNull,
+      ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> valueSerializerOpt.map(_.getClass).orNull)
+
+    val kafkaClients =
+      ConfigSettings.serializeAndMaskKafkaProperties(propertiesWithMandatoryKeys,
+        new org.apache.kafka.clients.producer.ProducerConfig(_))
     "org.apache.pekko.kafka.ProducerSettings(" +
     s"properties=$kafkaClients," +
     s"keySerializer=$keySerializerOpt," +

--- a/tests/src/test/scala/org/apache/pekko/kafka/ConsumerSettingsSpec.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/ConsumerSettingsSpec.scala
@@ -109,11 +109,14 @@ class ConsumerSettingsSpec
       val settings = ConsumerSettings(conf, new ByteArrayDeserializer, new StringDeserializer)
         .withProperty(SslConfigs.SSL_KEY_PASSWORD_CONFIG, "hemligt")
         .withProperty("ssl.truststore.password", "geheim")
+        .withProperty("ssl.keystore.key", "schlussel")
       val s = settings.toString
       s should include(SslConfigs.SSL_KEY_PASSWORD_CONFIG)
       (s should not).include("hemligt")
       s should include("ssl.truststore.password")
       (s should not).include("geheim")
+      s should include("ssl.keystore.key")
+      (s should not).include("schlussel")
     }
 
     "throw IllegalArgumentException if no value deserializer defined" in {

--- a/tests/src/test/scala/org/apache/pekko/kafka/ProducerSettingsSpec.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/ProducerSettingsSpec.scala
@@ -93,11 +93,14 @@ class ProducerSettingsSpec
       val settings = ProducerSettings(conf, new ByteArraySerializer, new StringSerializer)
         .withProperty(SslConfigs.SSL_KEY_PASSWORD_CONFIG, "hemligt")
         .withProperty("ssl.truststore.password", "geheim")
+        .withProperty("ssl.keystore.key", "schlussel")
       val s = settings.toString
       s should include(SslConfigs.SSL_KEY_PASSWORD_CONFIG)
       (s should not).include("hemligt")
       s should include("ssl.truststore.password")
       (s should not).include("geheim")
+      s should include("ssl.keystore.key")
+      (s should not).include("schlussel")
     }
 
     "throw IllegalArgumentException if no value serializer defined" in {


### PR DESCRIPTION
Resolves: https://github.com/apache/incubator-pekko-connectors-kafka/issues/85

This PR reuses the upstream Kafka mechanism that is used to filter/mask passwords which means its 100% correct (the `.properties` fields being printed in `.toString` refers to configuration that is passed to proper Kafka). In more detail, Kafka has its own `org.apache.kafka.common.config.AbstractConfig` which actually maintains types for keys. One of those types is `kafka.common.config.ConfigDef.Type.PASSWORD` which is how upstream Kafka determines whether any sensitive field needs to be masked (see https://github.com/apache/kafka/blob/51bc41031b91b16ffcbd95832e8a20a00d3b6f81/clients/src/main/java/org/apache/kafka/common/config/types/Password.java#L54-L57 for more info).

Also note that this project already has tests for determining if the filtering is working (see https://github.com/mdedetrich/incubator-pekko-connectors-kafka/blob/0a55b158d2d7fd8c050ab147d80d259a79e3ffe2/tests/src/test/scala/org/apache/pekko/kafka/ConsumerSettingsSpec.scala#L107-L117 and https://github.com/mdedetrich/incubator-pekko-connectors-kafka/blob/0a55b158d2d7fd8c050ab147d80d259a79e3ffe2/tests/src/test/scala/org/apache/pekko/kafka/ProducerSettingsSpec.scala#L91-L101) so I can confirm that it works (i.e. there is no regression).