### PR TITLE
add alpakka-kafka prefix to version numbers

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -180,7 +180,7 @@ pekko.kafka.committer {
   # API may change.
   # Delivery of commits to the internal actor
   # WaitForAck: Expect replies for commits, and backpressure the stream if replies do not arrive.
-  # SendAndForget: Send off commits to the internal actor without expecting replies (experimental feature since 1.1)
+  # SendAndForget: Send off commits to the internal actor without expecting replies (experimental feature since alpakka-kafka 1.1)
   delivery = WaitForAck
 
   # API may change.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -180,7 +180,7 @@ pekko.kafka.committer {
   # API may change.
   # Delivery of commits to the internal actor
   # WaitForAck: Expect replies for commits, and backpressure the stream if replies do not arrive.
-  # SendAndForget: Send off commits to the internal actor without expecting replies (experimental feature since alpakka-kafka 1.1)
+  # SendAndForget: Send off commits to the internal actor without expecting replies (experimental feature since Alpakka Kafka 1.1)
   delivery = WaitForAck
 
   # API may change.

--- a/core/src/main/scala/org/apache/pekko/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/ConsumerMessage.scala
@@ -57,14 +57,14 @@ object ConsumerMessage {
    * or a number of offsets aggregated as [[CommittableOffsetBatch]].
    */
   @DoNotInherit trait Committable {
-    @deprecated("use `Committer.flow` or `Committer.sink` instead of direct usage", "alpakka-kafka 2.0.0")
+    @deprecated("use `Committer.flow` or `Committer.sink` instead of direct usage", "Alpakka Kafka 2.0.0")
     def commitScaladsl(): Future[Done]
 
     /**
-     * @deprecated use `Committer.flow` or `Committer.sink` instead of direct usage, since alpakka-kafka 2.0.0
+     * @deprecated use `Committer.flow` or `Committer.sink` instead of direct usage, since Alpakka Kafka 2.0.0
      */
     @java.lang.Deprecated
-    @deprecated("use `Committer.flow` or `Committer.sink` instead of direct usage", "alpakka-kafka 2.0.0")
+    @deprecated("use `Committer.flow` or `Committer.sink` instead of direct usage", "Alpakka Kafka 2.0.0")
     def commitJavadsl(): CompletionStage[Done]
 
     @InternalApi

--- a/core/src/main/scala/org/apache/pekko/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/ConsumerMessage.scala
@@ -57,14 +57,14 @@ object ConsumerMessage {
    * or a number of offsets aggregated as [[CommittableOffsetBatch]].
    */
   @DoNotInherit trait Committable {
-    @deprecated("use `Committer.flow` or `Committer.sink` instead of direct usage", "2.0.0")
+    @deprecated("use `Committer.flow` or `Committer.sink` instead of direct usage", "alpakka-kafka 2.0.0")
     def commitScaladsl(): Future[Done]
 
     /**
-     * @deprecated use `Committer.flow` or `Committer.sink` instead of direct usage, since 2.0.0
+     * @deprecated use `Committer.flow` or `Committer.sink` instead of direct usage, since alpakka-kafka 2.0.0
      */
     @java.lang.Deprecated
-    @deprecated("use `Committer.flow` or `Committer.sink` instead of direct usage", "2.0.0")
+    @deprecated("use `Committer.flow` or `Committer.sink` instead of direct usage", "alpakka-kafka 2.0.0")
     def commitJavadsl(): CompletionStage[Done]
 
     @InternalApi

--- a/core/src/main/scala/org/apache/pekko/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/ConsumerSettings.scala
@@ -503,7 +503,7 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
   /**
    * Scala API.
    * A hook to allow for resolving some settings asynchronously.
-   * @since 2.0.0
+   * @since alpakka-kafka 2.0.0
    */
   def withEnrichAsync(value: ConsumerSettings[K, V] => Future[ConsumerSettings[K, V]]): ConsumerSettings[K, V] =
     copy(enrichAsync = Some(value))
@@ -511,7 +511,7 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
   /**
    * Java API.
    * A hook to allow for resolving some settings asynchronously.
-   * @since 2.0.0
+   * @since alpakka-kafka 2.0.0
    */
   def withEnrichCompletionStage(
       value: java.util.function.Function[ConsumerSettings[K, V], CompletionStage[ConsumerSettings[K, V]]])

--- a/core/src/main/scala/org/apache/pekko/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/ConsumerSettings.scala
@@ -503,7 +503,7 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
   /**
    * Scala API.
    * A hook to allow for resolving some settings asynchronously.
-   * @since alpakka-kafka 2.0.0
+   * @since Alpakka Kafka 2.0.0
    */
   def withEnrichAsync(value: ConsumerSettings[K, V] => Future[ConsumerSettings[K, V]]): ConsumerSettings[K, V] =
     copy(enrichAsync = Some(value))
@@ -511,7 +511,7 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
   /**
    * Java API.
    * A hook to allow for resolving some settings asynchronously.
-   * @since alpakka-kafka 2.0.0
+   * @since Alpakka Kafka 2.0.0
    */
   def withEnrichCompletionStage(
       value: java.util.function.Function[ConsumerSettings[K, V], CompletionStage[ConsumerSettings[K, V]]])

--- a/core/src/main/scala/org/apache/pekko/kafka/Metadata.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/Metadata.scala
@@ -180,10 +180,10 @@ object Metadata {
   /**
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
    */
-  @deprecated("use `GetCommittedOffsets`", "2.0.3")
+  @deprecated("use `GetCommittedOffsets`", "alpakka-kafka 2.0.3")
   final case class GetCommittedOffset(partition: TopicPartition) extends Request with NoSerializationVerificationNeeded
 
-  @deprecated("use `CommittedOffsets`", "2.0.3")
+  @deprecated("use `CommittedOffsets`", "alpakka-kafka 2.0.3")
   final case class CommittedOffset(response: Try[OffsetAndMetadata], requestedPartition: TopicPartition)
       extends Response
       with NoSerializationVerificationNeeded {
@@ -198,7 +198,7 @@ object Metadata {
    * Java API:
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
    */
-  @deprecated("use `createGetCommittedOffsets`", "2.0.3")
+  @deprecated("use `createGetCommittedOffsets`", "alpakka-kafka 2.0.3")
   def createGetCommittedOffset(partition: TopicPartition): GetCommittedOffset = GetCommittedOffset(partition)
 
   /**

--- a/core/src/main/scala/org/apache/pekko/kafka/Metadata.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/Metadata.scala
@@ -180,10 +180,10 @@ object Metadata {
   /**
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
    */
-  @deprecated("use `GetCommittedOffsets`", "alpakka-kafka 2.0.3")
+  @deprecated("use `GetCommittedOffsets`", "Alpakka Kafka 2.0.3")
   final case class GetCommittedOffset(partition: TopicPartition) extends Request with NoSerializationVerificationNeeded
 
-  @deprecated("use `CommittedOffsets`", "alpakka-kafka 2.0.3")
+  @deprecated("use `CommittedOffsets`", "Alpakka Kafka 2.0.3")
   final case class CommittedOffset(response: Try[OffsetAndMetadata], requestedPartition: TopicPartition)
       extends Response
       with NoSerializationVerificationNeeded {
@@ -198,7 +198,7 @@ object Metadata {
    * Java API:
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
    */
-  @deprecated("use `createGetCommittedOffsets`", "alpakka-kafka 2.0.3")
+  @deprecated("use `createGetCommittedOffsets`", "Alpakka Kafka 2.0.3")
   def createGetCommittedOffset(partition: TopicPartition): GetCommittedOffset = GetCommittedOffset(partition)
 
   /**

--- a/core/src/main/scala/org/apache/pekko/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/ProducerSettings.scala
@@ -232,7 +232,7 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
 
   @deprecated(
     "Use createKafkaProducer(), createKafkaProducerAsync(), or createKafkaProducerCompletionStage() to get a new KafkaProducer",
-    "2.0.0")
+    "alpakka-kafka 2.0.0")
   def producerFactory: ProducerSettings[K, V] => Producer[K, V] = _ => createKafkaProducer()
 
   /**
@@ -335,7 +335,7 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
   /**
    * Scala API.
    * A hook to allow for resolving some settings asynchronously.
-   * @since 2.0.0
+   * @since alpakka-kafka 2.0.0
    */
   def withEnrichAsync(value: ProducerSettings[K, V] => Future[ProducerSettings[K, V]]): ProducerSettings[K, V] =
     copy(enrichAsync = Some(value))
@@ -343,7 +343,7 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
   /**
    * Java API.
    * A hook to allow for resolving some settings asynchronously.
-   * @since 2.0.0
+   * @since alpakka-kafka 2.0.0
    */
   def withEnrichCompletionStage(
       value: java.util.function.Function[ProducerSettings[K, V], CompletionStage[ProducerSettings[K, V]]])

--- a/core/src/main/scala/org/apache/pekko/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/ProducerSettings.scala
@@ -232,7 +232,7 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
 
   @deprecated(
     "Use createKafkaProducer(), createKafkaProducerAsync(), or createKafkaProducerCompletionStage() to get a new KafkaProducer",
-    "alpakka-kafka 2.0.0")
+    "Alpakka Kafka 2.0.0")
   def producerFactory: ProducerSettings[K, V] => Producer[K, V] = _ => createKafkaProducer()
 
   /**
@@ -335,7 +335,7 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
   /**
    * Scala API.
    * A hook to allow for resolving some settings asynchronously.
-   * @since alpakka-kafka 2.0.0
+   * @since Alpakka Kafka 2.0.0
    */
   def withEnrichAsync(value: ProducerSettings[K, V] => Future[ProducerSettings[K, V]]): ProducerSettings[K, V] =
     copy(enrichAsync = Some(value))
@@ -343,7 +343,7 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
   /**
    * Java API.
    * A hook to allow for resolving some settings asynchronously.
-   * @since alpakka-kafka 2.0.0
+   * @since Alpakka Kafka 2.0.0
    */
   def withEnrichCompletionStage(
       value: java.util.function.Function[ProducerSettings[K, V], CompletionStage[ProducerSettings[K, V]]])

--- a/core/src/main/scala/org/apache/pekko/kafka/RestrictedConsumer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/RestrictedConsumer.scala
@@ -46,7 +46,7 @@ final class RestrictedConsumer(consumer: Consumer[_, _], duration: java.time.Dur
   /**
    * See [[org.apache.kafka.clients.consumer.KafkaConsumer#committed(TopicPartition,java.time.Duration)]]
    */
-  @deprecated("use `committed(java.util.Set[TopicPartition])`", "2.0.5")
+  @deprecated("use `committed(java.util.Set[TopicPartition])`", "alpakka-kafka 2.0.5")
   def committed(tp: TopicPartition): OffsetAndMetadata = consumer.committed(tp, duration)
 
   /**

--- a/core/src/main/scala/org/apache/pekko/kafka/RestrictedConsumer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/RestrictedConsumer.scala
@@ -46,7 +46,7 @@ final class RestrictedConsumer(consumer: Consumer[_, _], duration: java.time.Dur
   /**
    * See [[org.apache.kafka.clients.consumer.KafkaConsumer#committed(TopicPartition,java.time.Duration)]]
    */
-  @deprecated("use `committed(java.util.Set[TopicPartition])`", "alpakka-kafka 2.0.5")
+  @deprecated("use `committed(java.util.Set[TopicPartition])`", "Alpakka Kafka 2.0.5")
   def committed(tp: TopicPartition): OffsetAndMetadata = consumer.committed(tp, duration)
 
   /**

--- a/core/src/main/scala/org/apache/pekko/kafka/Subscriptions.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/Subscriptions.scala
@@ -42,12 +42,12 @@ sealed trait Subscription {
  */
 sealed trait ManualSubscription extends Subscription {
 
-  /** @deprecated Manual subscriptions do never rebalance, since 1.0-RC1 */
-  @deprecated("Manual subscription does never rebalance", "1.0-RC1")
+  /** @deprecated Manual subscriptions do never rebalance, since alpakka-kafka 1.0-RC1 */
+  @deprecated("Manual subscription does never rebalance", "alpakka-kafka 1.0-RC1")
   def rebalanceListener: Option[ActorRef] = None
 
-  /** @deprecated Manual subscriptions do never rebalance, since 1.0-RC1 */
-  @deprecated("Manual subscription does never rebalance", "1.0-RC1")
+  /** @deprecated Manual subscriptions do never rebalance, since alpakka-kafka 1.0-RC1 */
+  @deprecated("Manual subscription does never rebalance", "alpakka-kafka 1.0-RC1")
   def withRebalanceListener(ref: ActorRef): ManualSubscription
 }
 

--- a/core/src/main/scala/org/apache/pekko/kafka/Subscriptions.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/Subscriptions.scala
@@ -42,12 +42,12 @@ sealed trait Subscription {
  */
 sealed trait ManualSubscription extends Subscription {
 
-  /** @deprecated Manual subscriptions do never rebalance, since alpakka-kafka 1.0-RC1 */
-  @deprecated("Manual subscription does never rebalance", "alpakka-kafka 1.0-RC1")
+  /** @deprecated Manual subscriptions do never rebalance, since Alpakka Kafka 1.0-RC1 */
+  @deprecated("Manual subscription does never rebalance", "Alpakka Kafka 1.0-RC1")
   def rebalanceListener: Option[ActorRef] = None
 
-  /** @deprecated Manual subscriptions do never rebalance, since alpakka-kafka 1.0-RC1 */
-  @deprecated("Manual subscription does never rebalance", "alpakka-kafka 1.0-RC1")
+  /** @deprecated Manual subscriptions do never rebalance, since Alpakka Kafka 1.0-RC1 */
+  @deprecated("Manual subscription does never rebalance", "Alpakka Kafka 1.0-RC1")
   def withRebalanceListener(ref: ActorRef): ManualSubscription
 }
 

--- a/core/src/main/scala/org/apache/pekko/kafka/javadsl/MetadataClient.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/javadsl/MetadataClient.scala
@@ -77,7 +77,7 @@ class MetadataClient private (metadataClient: pekko.kafka.scaladsl.MetadataClien
       }(ExecutionContexts.parasitic)
       .asJava
 
-  @deprecated("use `getCommittedOffsets`", "alpakka-kafka 2.0.3")
+  @deprecated("use `getCommittedOffsets`", "Alpakka Kafka 2.0.3")
   def getCommittedOffset(partition: TopicPartition): CompletionStage[OffsetAndMetadata] =
     metadataClient
       .getCommittedOffset(partition)

--- a/core/src/main/scala/org/apache/pekko/kafka/javadsl/MetadataClient.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/javadsl/MetadataClient.scala
@@ -77,7 +77,7 @@ class MetadataClient private (metadataClient: pekko.kafka.scaladsl.MetadataClien
       }(ExecutionContexts.parasitic)
       .asJava
 
-  @deprecated("use `getCommittedOffsets`", "2.0.3")
+  @deprecated("use `getCommittedOffsets`", "alpakka-kafka 2.0.3")
   def getCommittedOffset(partition: TopicPartition): CompletionStage[OffsetAndMetadata] =
     metadataClient
       .getCommittedOffset(partition)

--- a/core/src/main/scala/org/apache/pekko/kafka/javadsl/Producer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/javadsl/Producer.scala
@@ -52,7 +52,7 @@ object Producer {
    *
    * Supports sharing a Kafka Producer instance.
    *
-   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since alpakka-kafka 2.0.0
+   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since Alpakka Kafka 2.0.0
    */
   @Deprecated
   def plainSink[K, V](
@@ -76,7 +76,7 @@ object Producer {
    * Note that there is a risk that something fails after publishing but before
    * committing, so it is "at-least once delivery" semantics.
    *
-   * @deprecated use `committableSink(ProducerSettings, CommitterSettings)` instead, since alpakka-kafka 2.0.0
+   * @deprecated use `committableSink(ProducerSettings, CommitterSettings)` instead, since Alpakka Kafka 2.0.0
    */
   @Deprecated
   def committableSink[K, V, IN <: Envelope[K, V, ConsumerMessage.Committable]](
@@ -107,7 +107,7 @@ object Producer {
    *
    * Supports sharing a Kafka Producer instance.
    *
-   * @deprecated use `committableSink(ProducerSettings, CommitterSettings)` instead, since alpakka-kafka 2.0.0
+   * @deprecated use `committableSink(ProducerSettings, CommitterSettings)` instead, since Alpakka Kafka 2.0.0
    */
   @Deprecated
   def committableSink[K, V](
@@ -266,7 +266,7 @@ object Producer {
    *
    * Supports sharing a Kafka Producer instance.
    *
-   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since alpakka-kafka 2.0.0
+   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since Alpakka Kafka 2.0.0
    */
   @Deprecated
   def flexiFlow[K, V, PassThrough](
@@ -294,7 +294,7 @@ object Producer {
    *
    * @tparam C the flow context type
    *
-   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since alpakka-kafka 2.0.0
+   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since Alpakka Kafka 2.0.0
    */
   @Deprecated
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/880")

--- a/core/src/main/scala/org/apache/pekko/kafka/javadsl/Producer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/javadsl/Producer.scala
@@ -52,7 +52,7 @@ object Producer {
    *
    * Supports sharing a Kafka Producer instance.
    *
-   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since 2.0.0
+   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since alpakka-kafka 2.0.0
    */
   @Deprecated
   def plainSink[K, V](
@@ -76,7 +76,7 @@ object Producer {
    * Note that there is a risk that something fails after publishing but before
    * committing, so it is "at-least once delivery" semantics.
    *
-   * @deprecated use `committableSink(ProducerSettings, CommitterSettings)` instead, since 2.0.0
+   * @deprecated use `committableSink(ProducerSettings, CommitterSettings)` instead, since alpakka-kafka 2.0.0
    */
   @Deprecated
   def committableSink[K, V, IN <: Envelope[K, V, ConsumerMessage.Committable]](
@@ -107,7 +107,7 @@ object Producer {
    *
    * Supports sharing a Kafka Producer instance.
    *
-   * @deprecated use `committableSink(ProducerSettings, CommitterSettings)` instead, since 2.0.0
+   * @deprecated use `committableSink(ProducerSettings, CommitterSettings)` instead, since alpakka-kafka 2.0.0
    */
   @Deprecated
   def committableSink[K, V](
@@ -266,7 +266,7 @@ object Producer {
    *
    * Supports sharing a Kafka Producer instance.
    *
-   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since 2.0.0
+   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since alpakka-kafka 2.0.0
    */
   @Deprecated
   def flexiFlow[K, V, PassThrough](
@@ -294,7 +294,7 @@ object Producer {
    *
    * @tparam C the flow context type
    *
-   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since 2.0.0
+   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since alpakka-kafka 2.0.0
    */
   @Deprecated
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/880")

--- a/core/src/main/scala/org/apache/pekko/kafka/javadsl/SendProducer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/javadsl/SendProducer.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.clients.producer.{ ProducerRecord, RecordMetadata }
 final class SendProducer[K, V] private (underlying: scaladsl.SendProducer[K, V]) {
 
   // kept for bin-compatibility
-  @deprecated("use the variant with ClassicActorSystemProvider instead", "alpakka-kafka 2.0.5")
+  @deprecated("use the variant with ClassicActorSystemProvider instead", "Alpakka Kafka 2.0.5")
   private[kafka] def this(settings: ProducerSettings[K, V], system: ActorSystem) =
     this(scaladsl.SendProducer(settings)(system))
 

--- a/core/src/main/scala/org/apache/pekko/kafka/javadsl/SendProducer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/javadsl/SendProducer.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.clients.producer.{ ProducerRecord, RecordMetadata }
 final class SendProducer[K, V] private (underlying: scaladsl.SendProducer[K, V]) {
 
   // kept for bin-compatibility
-  @deprecated("use the variant with ClassicActorSystemProvider instead", "2.0.5")
+  @deprecated("use the variant with ClassicActorSystemProvider instead", "alpakka-kafka 2.0.5")
   private[kafka] def this(settings: ProducerSettings[K, V], system: ActorSystem) =
     this(scaladsl.SendProducer(settings)(system))
 

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/Consumer.scala
@@ -110,7 +110,7 @@ object Consumer {
 
     override def stop(): Future[Done] = control.stop()
 
-    @deprecated("Use `drainAndShutdown` for proper shutdown of the stream.", "alpakka-kafka 2.0.0")
+    @deprecated("Use `drainAndShutdown` for proper shutdown of the stream.", "Alpakka Kafka 2.0.0")
     override def shutdown(): Future[Done] =
       control
         .shutdown()

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/Consumer.scala
@@ -110,7 +110,7 @@ object Consumer {
 
     override def stop(): Future[Done] = control.stop()
 
-    @deprecated("Use `drainAndShutdown` for proper shutdown of the stream.", "2.0.0")
+    @deprecated("Use `drainAndShutdown` for proper shutdown of the stream.", "alpakka-kafka 2.0.0")
     override def shutdown(): Future[Done] =
       control
         .shutdown()

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/MetadataClient.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/MetadataClient.scala
@@ -76,7 +76,7 @@ class MetadataClient private (consumerActor: ActorRef, timeout: Timeout, managed
         case Failure(e)   => Future.failed(e)
       }(ExecutionContexts.parasitic)
 
-  @deprecated("use `getCommittedOffsets`", "2.0.3")
+  @deprecated("use `getCommittedOffsets`", "alpakka-kafka 2.0.3")
   def getCommittedOffset(partition: TopicPartition): Future[OffsetAndMetadata] =
     (consumerActor ? GetCommittedOffset(partition))(timeout)
       .mapTo[CommittedOffset]

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/MetadataClient.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/MetadataClient.scala
@@ -76,7 +76,7 @@ class MetadataClient private (consumerActor: ActorRef, timeout: Timeout, managed
         case Failure(e)   => Future.failed(e)
       }(ExecutionContexts.parasitic)
 
-  @deprecated("use `getCommittedOffsets`", "alpakka-kafka 2.0.3")
+  @deprecated("use `getCommittedOffsets`", "Alpakka Kafka 2.0.3")
   def getCommittedOffset(partition: TopicPartition): Future[OffsetAndMetadata] =
     (consumerActor ? GetCommittedOffset(partition))(timeout)
       .mapTo[CommittedOffset]

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/Producer.scala
@@ -54,7 +54,7 @@ object Producer {
    */
   @deprecated(
     "Pass in external or shared producer using ProducerSettings.withProducerFactory or ProducerSettings.withProducer",
-    "2.0.0")
+    "alpakka-kafka 2.0.0")
   def plainSink[K, V](
       settings: ProducerSettings[K, V],
       producer: org.apache.kafka.clients.producer.Producer[K, V]): Sink[ProducerRecord[K, V], Future[Done]] =
@@ -76,7 +76,7 @@ object Producer {
    * Note that there is a risk that something fails after publishing but before
    * committing, so it is "at-least once delivery" semantics.
    */
-  @deprecated("use `committableSink(ProducerSettings, CommitterSettings)` instead", "2.0.0")
+  @deprecated("use `committableSink(ProducerSettings, CommitterSettings)` instead", "alpakka-kafka 2.0.0")
   def committableSink[K, V](
       settings: ProducerSettings[K, V]): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] =
     flexiFlow[K, V, ConsumerMessage.Committable](settings)
@@ -101,7 +101,7 @@ object Producer {
    *
    * Supports sharing a Kafka Producer instance.
    */
-  @deprecated("use `committableSink(ProducerSettings, CommitterSettings)` instead", "2.0.0")
+  @deprecated("use `committableSink(ProducerSettings, CommitterSettings)` instead", "alpakka-kafka 2.0.0")
   def committableSink[K, V](
       settings: ProducerSettings[K, V],
       producer: org.apache.kafka.clients.producer.Producer[K, V])
@@ -262,7 +262,7 @@ object Producer {
    */
   @deprecated(
     "Pass in external or shared producer using ProducerSettings.withProducerFactory or ProducerSettings.withProducer",
-    "2.0.0")
+    "alpakka-kafka 2.0.0")
   def flexiFlow[K, V, PassThrough](
       settings: ProducerSettings[K, V],
       producer: org.apache.kafka.clients.producer.Producer[K, V])
@@ -290,7 +290,7 @@ object Producer {
    */
   @deprecated(
     "Pass in external or shared producer using ProducerSettings.withProducerFactory or ProducerSettings.withProducer",
-    "2.0.0")
+    "alpakka-kafka 2.0.0")
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/880")
   def flowWithContext[K, V, C](
       settings: ProducerSettings[K, V],

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/Producer.scala
@@ -54,7 +54,7 @@ object Producer {
    */
   @deprecated(
     "Pass in external or shared producer using ProducerSettings.withProducerFactory or ProducerSettings.withProducer",
-    "alpakka-kafka 2.0.0")
+    "Alpakka Kafka 2.0.0")
   def plainSink[K, V](
       settings: ProducerSettings[K, V],
       producer: org.apache.kafka.clients.producer.Producer[K, V]): Sink[ProducerRecord[K, V], Future[Done]] =
@@ -76,7 +76,7 @@ object Producer {
    * Note that there is a risk that something fails after publishing but before
    * committing, so it is "at-least once delivery" semantics.
    */
-  @deprecated("use `committableSink(ProducerSettings, CommitterSettings)` instead", "alpakka-kafka 2.0.0")
+  @deprecated("use `committableSink(ProducerSettings, CommitterSettings)` instead", "Alpakka Kafka 2.0.0")
   def committableSink[K, V](
       settings: ProducerSettings[K, V]): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] =
     flexiFlow[K, V, ConsumerMessage.Committable](settings)
@@ -101,7 +101,7 @@ object Producer {
    *
    * Supports sharing a Kafka Producer instance.
    */
-  @deprecated("use `committableSink(ProducerSettings, CommitterSettings)` instead", "alpakka-kafka 2.0.0")
+  @deprecated("use `committableSink(ProducerSettings, CommitterSettings)` instead", "Alpakka Kafka 2.0.0")
   def committableSink[K, V](
       settings: ProducerSettings[K, V],
       producer: org.apache.kafka.clients.producer.Producer[K, V])
@@ -262,7 +262,7 @@ object Producer {
    */
   @deprecated(
     "Pass in external or shared producer using ProducerSettings.withProducerFactory or ProducerSettings.withProducer",
-    "alpakka-kafka 2.0.0")
+    "Alpakka Kafka 2.0.0")
   def flexiFlow[K, V, PassThrough](
       settings: ProducerSettings[K, V],
       producer: org.apache.kafka.clients.producer.Producer[K, V])
@@ -290,7 +290,7 @@ object Producer {
    */
   @deprecated(
     "Pass in external or shared producer using ProducerSettings.withProducerFactory or ProducerSettings.withProducer",
-    "alpakka-kafka 2.0.0")
+    "Alpakka Kafka 2.0.0")
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/880")
   def flowWithContext[K, V, C](
       settings: ProducerSettings[K, V],

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/SendProducer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/SendProducer.scala
@@ -110,7 +110,7 @@ object SendProducer {
     new SendProducer(settings, system.classicSystem)
 
   // kept for bin-compatibility
-  @deprecated("use the variant with ClassicActorSystemProvider instead", "alpakka-kafka 2.0.5")
+  @deprecated("use the variant with ClassicActorSystemProvider instead", "Alpakka Kafka 2.0.5")
   def apply[K, V](settings: ProducerSettings[K, V], system: ActorSystem): SendProducer[K, V] =
     new SendProducer(settings, system)
 }

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/SendProducer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/SendProducer.scala
@@ -110,7 +110,7 @@ object SendProducer {
     new SendProducer(settings, system.classicSystem)
 
   // kept for bin-compatibility
-  @deprecated("use the variant with ClassicActorSystemProvider instead", "2.0.5")
+  @deprecated("use the variant with ClassicActorSystemProvider instead", "alpakka-kafka 2.0.5")
   def apply[K, V](settings: ProducerSettings[K, V], system: ActorSystem): SendProducer[K, V] =
     new SendProducer(settings, system)
 }

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/KafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/KafkaTest.java
@@ -34,7 +34,7 @@ public abstract class KafkaTest extends BaseKafkaTest {
 
   /**
    * @deprecated Materializer no longer necessary in Akka 2.6, use
-   *     `KafkaTest(ClassicActorSystemProvider, String)` instead, since alpakka-kafka 2.1.0
+   *     `KafkaTest(ClassicActorSystemProvider, String)` instead, since Alpakka Kafka 2.1.0
    */
   @Deprecated
   protected KafkaTest(ActorSystem system, Materializer mat, String bootstrapServers) {

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/KafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/KafkaTest.java
@@ -34,7 +34,7 @@ public abstract class KafkaTest extends BaseKafkaTest {
 
   /**
    * @deprecated Materializer no longer necessary in Akka 2.6, use
-   *     `KafkaTest(ClassicActorSystemProvider, String)` instead, since 2.1.0
+   *     `KafkaTest(ClassicActorSystemProvider, String)` instead, since alpakka-kafka 2.1.0
    */
   @Deprecated
   protected KafkaTest(ActorSystem system, Materializer mat, String bootstrapServers) {

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
@@ -38,7 +38,7 @@ public abstract class TestcontainersKafkaJunit4Test extends KafkaJunit4Test {
 
   /**
    * @deprecated Materializer no longer necessary in Akka 2.6, use
-   *     `TestcontainersKafkaJunit4Test(ClassicActorSystemProvider)` instead, since 2.1.0
+   *     `TestcontainersKafkaJunit4Test(ClassicActorSystemProvider)` instead, since alpakka-kafka 2.1.0
    */
   @Deprecated
   protected TestcontainersKafkaJunit4Test(ActorSystem system, Materializer mat) {

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
@@ -38,7 +38,7 @@ public abstract class TestcontainersKafkaJunit4Test extends KafkaJunit4Test {
 
   /**
    * @deprecated Materializer no longer necessary in Akka 2.6, use
-   *     `TestcontainersKafkaJunit4Test(ClassicActorSystemProvider)` instead, since alpakka-kafka
+   *     `TestcontainersKafkaJunit4Test(ClassicActorSystemProvider)` instead, since Alpakka Kafka
    *     2.1.0
    */
   @Deprecated

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
@@ -38,7 +38,8 @@ public abstract class TestcontainersKafkaJunit4Test extends KafkaJunit4Test {
 
   /**
    * @deprecated Materializer no longer necessary in Akka 2.6, use
-   *     `TestcontainersKafkaJunit4Test(ClassicActorSystemProvider)` instead, since alpakka-kafka 2.1.0
+   *     `TestcontainersKafkaJunit4Test(ClassicActorSystemProvider)` instead, since alpakka-kafka
+   *     2.1.0
    */
   @Deprecated
   protected TestcontainersKafkaJunit4Test(ActorSystem system, Materializer mat) {

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaTest.java
@@ -39,7 +39,7 @@ public abstract class TestcontainersKafkaTest extends KafkaTest {
 
   /**
    * @deprecated Materializer no longer necessary in Akka 2.6, use
-   *     `TestcontainersKafkaTest(ClassicActorSystemProvider)` instead, since alpakka-kafka 2.1.0
+   *     `TestcontainersKafkaTest(ClassicActorSystemProvider)` instead, since Alpakka Kafka 2.1.0
    */
   @Deprecated
   protected TestcontainersKafkaTest(ActorSystem system, Materializer mat) {

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaTest.java
@@ -39,7 +39,7 @@ public abstract class TestcontainersKafkaTest extends KafkaTest {
 
   /**
    * @deprecated Materializer no longer necessary in Akka 2.6, use
-   *     `TestcontainersKafkaTest(ClassicActorSystemProvider)` instead, since 2.1.0
+   *     `TestcontainersKafkaTest(ClassicActorSystemProvider)` instead, since alpakka-kafka 2.1.0
    */
   @Deprecated
   protected TestcontainersKafkaTest(ActorSystem system, Materializer mat) {

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -57,7 +57,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
 
   /**
    * @deprecated Materializer no longer necessary in Akka 2.6, use
-   *     `BaseKafkaTest(ClassicActorSystemProvider, String)` instead, since alpakka-kafka 2.1.0
+   *     `BaseKafkaTest(ClassicActorSystemProvider, String)` instead, since Alpakka Kafka 2.1.0
    */
   @Deprecated
   protected BaseKafkaTest(ActorSystem system, Materializer mat, String bootstrapServers) {

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -57,7 +57,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
 
   /**
    * @deprecated Materializer no longer necessary in Akka 2.6, use
-   *     `BaseKafkaTest(ClassicActorSystemProvider, String)` instead, since 2.1.0
+   *     `BaseKafkaTest(ClassicActorSystemProvider, String)` instead, since alpakka-kafka 2.1.0
    */
   @Deprecated
   protected BaseKafkaTest(ActorSystem system, Materializer mat, String bootstrapServers) {

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/KafkaJunit4Test.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/KafkaJunit4Test.java
@@ -27,7 +27,7 @@ public abstract class KafkaJunit4Test extends BaseKafkaTest {
 
   /**
    * @deprecated Materializer no longer necessary in Akka 2.6, use
-   *     `KafkaJunit4Test(ClassicActorSystemProvider, String)` instead, since alpakka-kafka 2.1.0
+   *     `KafkaJunit4Test(ClassicActorSystemProvider, String)` instead, since Alpakka Kafka 2.1.0
    */
   @Deprecated
   protected KafkaJunit4Test(ActorSystem system, Materializer mat, String bootstrapServers) {

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/KafkaJunit4Test.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/KafkaJunit4Test.java
@@ -27,7 +27,7 @@ public abstract class KafkaJunit4Test extends BaseKafkaTest {
 
   /**
    * @deprecated Materializer no longer necessary in Akka 2.6, use
-   *     `KafkaJunit4Test(ClassicActorSystemProvider, String)` instead, since 2.1.0
+   *     `KafkaJunit4Test(ClassicActorSystemProvider, String)` instead, since alpakka-kafka 2.1.0
    */
   @Deprecated
   protected KafkaJunit4Test(ActorSystem system, Materializer mat, String bootstrapServers) {


### PR DESCRIPTION
Since the first pekko-connectors-kafka release is 1.0.0, we need to make sure that the alpakka-kafka version numbers in deprecation messages are explicit about the fact the version number is alpakka-kafka related.