### PR TITLE
remove copyright from kafka license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -205,4 +205,3 @@
 pekko-connectors-kafka-cluster-sharding contains KafkaClusterSharding.scala.
 This code is derived from a class in Apache Kafka <https://kafka.apache.org/>,
 licensed under the Apache 2.0 license.
-Copyright 2023 The Apache Software Foundation.


### PR DESCRIPTION
* the LICENSE in https://github.com/apache/kafka/blob/trunk/LICENSE does not have a copyright so remove the line in our LICENSE
* there is a copyright in the Kafka NOTICE and we have that copied into our NOTICE
* was part of https://github.com/apache/incubator-pekko-connectors-kafka/pull/103 but this bit is possibly less contentious