### PR TITLE
kafka 3.0.2 due to CVE

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -26,7 +26,7 @@ object Versions {
   val pekkoVersion = PekkoCoreDependency.version
 
   // Keep .scala-steward.conf pin in sync
-  val kafkaVersion = "3.0.1"
+  val kafkaVersion = "3.0.2"
   val KafkaVersionForDocs = "30"
   // This should align with the ScalaTest version used in the Apache Pekko 1.0.x testkit
   // https://github.com/apache/incubator-pekko/blob/main/project/Dependencies.scala


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-34917