### PR TITLE
Use latest pekko-sbt-paradox

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,8 @@ addCommandAlias("verifyDocs", ";+doc ;unidoc ;docs/paradoxBrowse")
 
 val mimaCompareVersion = "1.0.0"
 
+ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
+
 lazy val `pekko-connectors-kafka` =
   project
     .in(file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,14 +22,8 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 // Java 11 module names are not added https://github.com/ThoughtWorksInc/sbt-api-mappings/issues/58
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
+addSbtPlugin(("com.github.sbt" % "sbt-site-paradox" % "1.5.0").excludeAll(
+  "com.lightbend.paradox", "sbt-paradox"))
 
-// We have to deliberately use older versions of sbt-paradox because current Pekko sbt build
-// only loads on JDK 1.8 so we need to bring in older versions of parboiled which support JDK 1.8
-addSbtPlugin(("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.0").excludeAll(
-  "com.lightbend.paradox", "sbt-paradox",
-  "com.lightbend.paradox" % "sbt-paradox-apidoc",
-  "com.lightbend.paradox" % "sbt-paradox-project-info"))
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox" % "0.9.2").force())
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-apidoc" % "0.10.1").force())
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-project-info" % "2.0.0").force())
+resolvers += Resolver.ApacheMavenSnapshotsRepo
+addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.1-RC1+5-13892678-SNAPSHOT")


### PR DESCRIPTION
Since we have a CVE which may require a release (see https://github.com/apache/incubator-pekko-connectors-kafka/pull/140) lets also fix the generated paradox doc/site so it can get released alongside with it.

If pekko-sbt-paradox gets released beforehand then its trivial to just update the version