### PR TITLE
protect 1.1.x branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -59,6 +59,18 @@ github:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false
         required_approving_review_count: 1
+    1.1.x:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
+          - Check headers
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
 
 notifications:
   commits:              commits@pekko.apache.org


### PR DESCRIPTION
there are PRs for upgrading kafka client and server to support Kafka 4 so we should really start aiming at a 1.2.0 release 