### PR TITLE
chore: Add SendProducer#create method.

### DIFF
--- a/core/src/main/scala/org/apache/pekko/kafka/javadsl/SendProducer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/javadsl/SendProducer.scala
@@ -32,16 +32,18 @@ final class SendProducer[K, V] private (underlying: scaladsl.SendProducer[K, V])
   // kept for bin-compatibility
   @deprecated("use the variant with ClassicActorSystemProvider instead", "Alpakka Kafka 2.0.5")
   private[kafka] def this(settings: ProducerSettings[K, V], system: ActorSystem) =
-    this(scaladsl.SendProducer(settings)(system))
+    this(scaladsl.SendProducer.create(settings)(system))
 
   /**
    * Utility class for producing to Kafka without using Apache Pekko Streams.
    * @param settings producer settings used to create or access the [[org.apache.kafka.clients.producer.Producer]]
    *
    * The internal asynchronous operations run on the provided `Executor` (which may be an `ActorSystem`'s dispatcher).
+   *
+   * Every Producer will create a new Kafka Producer instance under the hood.
    */
   def this(settings: ProducerSettings[K, V], system: ClassicActorSystemProvider) =
-    this(scaladsl.SendProducer(settings)(system.classicSystem))
+    this(scaladsl.SendProducer.create(settings)(system.classicSystem))
 
   /**
    * Send records to Kafka topics and complete a future with the result.
@@ -71,4 +73,20 @@ final class SendProducer[K, V] private (underlying: scaladsl.SendProducer[K, V])
   def close(): CompletionStage[Done] = underlying.close().asJava
 
   override def toString: String = s"SendProducer(${underlying.settings})"
+}
+
+object SendProducer {
+
+  /**
+   * Utility class for producing to Kafka without using Apache Pekko Streams.
+   * @param settings producer settings used to create or access the [[org.apache.kafka.clients.producer.Producer]]
+   *
+   * The internal asynchronous operations run on the provided `Executor` (which may be an `ActorSystem`'s dispatcher).
+   *
+   * Every Producer will create a new Kafka Producer instance under the hood.
+   *
+   * @since 1.2.0
+   */
+  def create[K, V](settings: ProducerSettings[K, V], system: ClassicActorSystemProvider): SendProducer[K, V] =
+    new SendProducer(settings, system)
 }

--- a/core/src/main/scala/org/apache/pekko/kafka/javadsl/SendProducer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/javadsl/SendProducer.scala
@@ -30,14 +30,20 @@ import scala.jdk.FutureConverters._
  */
 final class SendProducer[K, V] private (underlying: scaladsl.SendProducer[K, V]) {
 
+  // kept for bin-compatibility
+  @deprecated("use the variant with ClassicActorSystemProvider instead", "Alpakka Kafka 2.0.5")
+  private[kafka] def this(settings: ProducerSettings[K, V], system: ActorSystem) =
+    this(scaladsl.SendProducer.create(settings)(system))
   /**
    * Utility class for producing to Kafka without using Apache Pekko Streams.
    * @param settings producer settings used to create or access the [[org.apache.kafka.clients.producer.Producer]]
    *
    * The internal asynchronous operations run on the provided `Executor` (which may be an `ActorSystem`'s dispatcher).
+   *
+   * Every Producer will create a new Kafka Producer instance under the hood.
    */
   def this(settings: ProducerSettings[K, V], system: ClassicActorSystemProvider) =
-    this(scaladsl.SendProducer(settings)(system.classicSystem))
+    this(scaladsl.SendProducer.create(settings)(system.classicSystem))
 
   /**
    * Send records to Kafka topics and complete a future with the result.
@@ -67,4 +73,20 @@ final class SendProducer[K, V] private (underlying: scaladsl.SendProducer[K, V])
   def close(): CompletionStage[Done] = underlying.close().asJava
 
   override def toString: String = s"SendProducer(${underlying.settings})"
+}
+
+object SendProducer {
+
+  /**
+   * Utility class for producing to Kafka without using Apache Pekko Streams.
+   * @param settings producer settings used to create or access the [[org.apache.kafka.clients.producer.Producer]]
+   *
+   * The internal asynchronous operations run on the provided `Executor` (which may be an `ActorSystem`'s dispatcher).
+   *
+   * Every Producer will create a new Kafka Producer instance under the hood.
+   *
+   * @since 1.2.0
+   */
+  def create[K, V](settings: ProducerSettings[K, V], system: ClassicActorSystemProvider): SendProducer[K, V] =
+    new SendProducer(settings, system)
 }

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/SendProducer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/SendProducer.scala
@@ -108,7 +108,6 @@ final class SendProducer[K, V] private (val settings: ProducerSettings[K, V], sy
 
 object SendProducer {
 
-  @deprecated("use create method instead", "1.2.0")
   def apply[K, V](settings: ProducerSettings[K, V])(implicit system: ClassicActorSystemProvider): SendProducer[K, V] =
     create(settings)
 

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/SendProducer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/SendProducer.scala
@@ -26,6 +26,7 @@ import scala.concurrent.{ ExecutionContext, Future, Promise }
 
 /**
  * Utility class for producing to Kafka without using Apache Pekko Streams.
+ *
  * @param settings producer settings used to create or access the [[org.apache.kafka.clients.producer.Producer]]
  */
 final class SendProducer[K, V] private (val settings: ProducerSettings[K, V], system: ActorSystem) {
@@ -106,7 +107,19 @@ final class SendProducer[K, V] private (val settings: ProducerSettings[K, V], sy
 }
 
 object SendProducer {
+
+  @deprecated("use create method instead", "1.2.0")
   def apply[K, V](settings: ProducerSettings[K, V])(implicit system: ClassicActorSystemProvider): SendProducer[K, V] =
+    create(settings)
+
+  /**
+   * Utility class for producing to Kafka without using Apache Pekko Streams.
+   * Every Producer will create a new Kafka Producer instance under the hood.
+   *
+   * @param settings producer settings used to create or access the [[org.apache.kafka.clients.producer.Producer]]
+   * @since 1.2.0
+   */
+  def create[K, V](settings: ProducerSettings[K, V])(implicit system: ClassicActorSystemProvider): SendProducer[K, V] =
     new SendProducer(settings, system.classicSystem)
 
   // kept for bin-compatibility

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/SendProducer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/SendProducer.scala
@@ -26,6 +26,7 @@ import scala.jdk.DurationConverters._
 
 /**
  * Utility class for producing to Kafka without using Apache Pekko Streams.
+ *
  * @param settings producer settings used to create or access the [[org.apache.kafka.clients.producer.Producer]]
  */
 final class SendProducer[K, V] private (val settings: ProducerSettings[K, V], system: ActorSystem) {
@@ -106,6 +107,18 @@ final class SendProducer[K, V] private (val settings: ProducerSettings[K, V], sy
 }
 
 object SendProducer {
+
+  @deprecated("use create method instead", "1.2.0")
   def apply[K, V](settings: ProducerSettings[K, V])(implicit system: ClassicActorSystemProvider): SendProducer[K, V] =
+    create(settings)
+
+  /**
+   * Utility class for producing to Kafka without using Apache Pekko Streams.
+   * Every Producer will create a new Kafka Producer instance under the hood.
+   *
+   * @param settings producer settings used to create or access the [[org.apache.kafka.clients.producer.Producer]]
+   * @since 1.2.0
+   */
+  def create[K, V](settings: ProducerSettings[K, V])(implicit system: ClassicActorSystemProvider): SendProducer[K, V] =
     new SendProducer(settings, system.classicSystem)
 }

--- a/java-tests/src/test/java/docs/javadsl/SendProducerTest.java
+++ b/java-tests/src/test/java/docs/javadsl/SendProducerTest.java
@@ -59,7 +59,7 @@ public class SendProducerTest extends TestcontainersKafkaTest {
 
     ProducerSettings<String, String> producerSettings = producerDefaults();
     // #record
-    SendProducer<String, String> producer = new SendProducer<>(producerSettings, system);
+    SendProducer<String, String> producer = SendProducer.create(producerSettings, system);
     try {
       CompletionStage<RecordMetadata> result =
           producer.send(new ProducerRecord<>(topic, "key", "value"));

--- a/tests/src/test/scala/docs/scaladsl/SendProducerSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SendProducerSpec.scala
@@ -33,7 +33,7 @@ class SendProducerSpec extends DocsSpecBase with TestcontainersKafkaLike {
     val topic1 = createTopic(1)
 
     // #record
-    val producer = SendProducer(producerDefaults)
+    val producer = SendProducer.create(producerDefaults)
     try {
       val send: Future[RecordMetadata] = producer
         .send(new ProducerRecord(topic1, "key", "value"))
@@ -54,7 +54,7 @@ class SendProducerSpec extends DocsSpecBase with TestcontainersKafkaLike {
   it should "send a multi-message (with one record)" in {
     val topic1 = createTopic(1)
 
-    val producer = SendProducer(producerDefaults)
+    val producer = SendProducer.create(producerDefaults)
     try {
       // #envelope
       val message = ProducerMessage.multi(immutable.Seq(new ProducerRecord(topic1, "key", "value")), "context")
@@ -80,7 +80,7 @@ class SendProducerSpec extends DocsSpecBase with TestcontainersKafkaLike {
     val topic1 = createTopic(1)
 
     // #multiMessage
-    val producer = SendProducer(producerDefaults)
+    val producer = SendProducer.create(producerDefaults)
     try {
       val envelope: ProducerMessage.Envelope[String, String, String] =
         ProducerMessage.multi(immutable.Seq(
@@ -108,7 +108,7 @@ class SendProducerSpec extends DocsSpecBase with TestcontainersKafkaLike {
 
   "Mis-configured producer" should "fail the send future" in {
     val topic1 = createTopic(1)
-    val producer = SendProducer(producerDefaults.withBootstrapServers("unkownhost"))
+    val producer = SendProducer.create(producerDefaults.withBootstrapServers("unkownhost"))
     try {
       val send = producer.send(new ProducerRecord(topic1, "key", "value"))
       send.failed.futureValue shouldBe a[org.apache.kafka.common.KafkaException]


### PR DESCRIPTION
refs: https://github.com/apache/pekko-connectors-kafka/issues/362

Motivation:
I think an explicit call `create` method will be better to indicate that some resource is been allocated.