### PR TITLE
avoid deprecated way to get ConsumerGroupMetadata

### DIFF
--- a/benchmarks/src/main/scala/org/apache/pekko/kafka/benchmarks/KafkaTransactionBenchmarks.scala
+++ b/benchmarks/src/main/scala/org/apache/pekko/kafka/benchmarks/KafkaTransactionBenchmarks.scala
@@ -49,7 +49,7 @@ object KafkaTransactionBenchmarks extends LazyLogging {
       accumulatedMsgCount = 0
       val offsetMap = Map(new TopicPartition(fixture.sourceTopic, 0) -> new OffsetAndMetadata(lastProcessedOffset))
       logger.debug("Committing offset " + offsetMap.head._2.offset())
-      producer.sendOffsetsToTransaction(offsetMap.asJava, new ConsumerGroupMetadata(fixture.groupId))
+      producer.sendOffsetsToTransaction(offsetMap.asJava, consumer.groupMetadata())
       producer.commitTransaction()
     }
 


### PR DESCRIPTION
* more needed
* relates to build issues in #466 