### PR TITLE
Add mockito as an agent

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val tests = project
   .settings(
     name := "pekko-connectors-kafka-tests",
     resolvers ++= ResolverSettings.testSpecificResolvers,
-    libraryDependencies ++= Dependencies.testDependencies,
+    libraryDependencies ++= Dependencies.testDependencies :+ Dependencies.mockito,
     publish / skip := true,
     Test / fork := true,
     Test / parallelExecution := false)

--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,8 @@ lazy val tests = project
     name := "pekko-connectors-kafka-tests",
     resolvers ++= ResolverSettings.testSpecificResolvers,
     libraryDependencies ++= Dependencies.testDependencies :+ Dependencies.mockito,
+    Test / javaOptions +=
+      s"-javaagent:${csrCacheDirectory.value.getAbsolutePath}/https/repo1.maven.org/maven2/org/mockito/mockito-core/${Versions.mockitoVersion}/mockito-core-${Versions.mockitoVersion}.jar",
     publish / skip := true,
     Test / fork := true,
     Test / parallelExecution := false)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,8 +39,9 @@ object Dependencies {
     "org.slf4j" % "log4j-over-slf4j" % slf4jVersion % Test,
     // Schema registry uses Glassfish which uses java.util.logging
     "org.slf4j" % "jul-to-slf4j" % slf4jVersion % Test,
-    "org.mockito" % "mockito-core" % "5.23.0" % Test,
     "com.thesamet.scalapb" %% "scalapb-runtime" % scalaPBVersion % Test)
+
+  lazy val mockito = "org.mockito" % "mockito-core" % mockitoVersion % Test
 
   lazy val testKitDependencies = Seq(
     "org.testcontainers" % "kafka" % testcontainersVersion % Provided,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -25,6 +25,7 @@ object Versions {
   val kafkaVersion = "4.1.2"
   val KafkaVersionForDocs = "37"
 
+  val mockitoVersion = "5.23.0"
   val scalaTestVersion = "3.2.19"
   val scalaPBVersion = "0.11.20"
   val testcontainersVersion = "1.21.4"


### PR DESCRIPTION
as per https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3. This resolves a warning the tests currently report.
The first commit extracts mockito from `testDependencies` so we only need to change the `javaOptions` in one project. Mockito is only used in the "tests" project, not in "int-tests" and not in "java-tests".