### PR TITLE
Address link to java.time.Duration$ in scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,8 +145,8 @@ lazy val docs = project
     Preprocess / preprocessRules := Seq(
       ("\\.java\\.scala".r, _ => ".java"), ("https://javadoc\\.io/page/".r, _ => "https://javadoc\\.io/static/"),
       // bug in Scaladoc
-      ("https://docs\\.oracle\\.com/en/java/javase/11/docs/api/java.base/java/time/Duration\\$.html".r,
-        _ => "https://docs\\.oracle\\.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html"),
+      ("https://docs\\.oracle\\.com/en/java/javase/17/docs/api/java.base/java/time/Duration\\$.html".r,
+        _ => "https://docs\\.oracle\\.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html"),
       // Add Java module name https://github.com/ThoughtWorksInc/sbt-api-mappings/issues/58
       ("https://docs\\.oracle\\.com/en/java/javase/11/docs/api/".r,
         _ => "https://docs\\.oracle\\.com/en/java/javase/11/docs/api/")),

--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ lazy val docs = project
       ("\\.java\\.scala".r, _ => ".java"), ("https://javadoc\\.io/page/".r, _ => "https://javadoc\\.io/static/"),
       // bug in Scaladoc
       ("https://docs\\.oracle\\.com/en/java/javase/17/docs/api/java.base/java/time/Duration\\$.html".r,
-        _ => "https://docs\\.oracle\\.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html"),
+        _ => "https://docs\\.oracle\\.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html")),
     Paradox / siteSubdirName := s"docs/pekko-connectors-kafka/${projectInfoVersion.value}",
     ParadoxSettings.settings)
 

--- a/core/src/main/scala/org/apache/pekko/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/ConsumerSettings.scala
@@ -432,7 +432,7 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
    * Java API:
    * If set to a finite duration, the consumer will re-send the last committed offsets periodically
    * for all assigned partitions. @see https://issues.apache.org/jira/browse/KAFKA-4682
-   * Set to [[java.time.Duration.ZERO]] to switch it off.
+   * Set to `java.time.Duration.ZERO` to switch it off.
    *
    * @see https://issues.apache.org/jira/browse/KAFKA-4682
    */


### PR DESCRIPTION
If I understand correctly the first commit _should_ fix the incorrect link. But I don't see any links getting rewritten. Maybe an upstream bug? I think that in the akka project folks experienced the same and decided to just use backticks to avoid having a link altogether: https://github.com/akka/alpakka-kafka/pull/1564/changes.
References https://github.com/apache/pekko-connectors-kafka/issues/368.