### PR TITLE
Allow simpler access to partition assignment strategies

### DIFF
--- a/core/src/main/scala/org/apache/pekko/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/ConsumerSettings.scala
@@ -294,6 +294,38 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
 
   /**
    * Scala API:
+   * A list of class names or class types, ordered by preference, of supported
+   * partition assignment strategies that the client will use to distribute
+   * partition ownership amongst consumer instances when group management is used.
+   *
+   * See https://kafka.apache.org/documentation/#consumerconfigs_partition.assignment.strategy
+   */
+  def withPartitionAssignmentStrategies(strategies: List[String]): ConsumerSettings[K, V] =
+    withProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, strategies.mkString(","))
+
+  /**
+   * Java API:
+   * A list of class names or class types, ordered by preference, of supported
+   * partition assignment strategies that the client will use to distribute
+   * partition ownership amongst consumer instances when group management is used.
+   *
+   * See https://kafka.apache.org/documentation/#consumerconfigs_partition.assignment.strategy
+   */
+  def withPartitionAssignmentStrategies(strategies: Array[String]): ConsumerSettings[K, V] =
+    withPartitionAssignmentStrategies(strategies.toList)
+
+  /**
+   * Sets the `CooperativeStickyAssignor` assignment strategy.
+   *
+   * @see https://kafka.apache.org/documentation/#consumerconfigs_partition.assignment.strategy
+   * @see https://kafka.apache.org/33/documentation.html#upgrade_300_notable
+   */
+  def withPartitionAssignmentStrategyCooperativeStickyAssignor(): ConsumerSettings[K, V] =
+    withProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
+      classOf[org.apache.kafka.clients.consumer.CooperativeStickyAssignor].getName)
+
+  /**
+   * Scala API:
    * The raw properties of the kafka-clients driver, see constants in
    * [[org.apache.kafka.clients.consumer.ConsumerConfig]].
    */

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -49,6 +49,7 @@ When creating a consumer source you need to pass in @apidoc[ConsumerSettings] th
 * bootstrap servers of the Kafka cluster (see @ref:[Service discovery](discovery.md) to defer the server configuration)
 * group id for the consumer, note that offsets are always committed for a given consumer group
 * Kafka consumer tuning parameters
+* assignment strategies
 
 Apache Pekko Connectors Kafka's defaults for all settings are defined in `reference.conf` which is included in the library JAR.
 
@@ -58,6 +59,8 @@ Important consumer settings
 | stop-timeout | The stage will delay stopping the internal actor to allow processing of messages already in the stream (required for successful committing). This can be set to 0 for streams using @apidoc[Consumer.DrainingControl] |
 | kafka-clients | Section for properties passed unchanged to the Kafka client (see @extref:[Kafka's Consumer Configs](kafka:/documentation.html#consumerconfigs)) |
 | connection-checker | Configuration to let the stream fail if the connection to the Kafka broker fails. |
+
+Explicitly selecting a [Consumer Assignment Strategy](https://kafka.apache.org/documentation/#consumerconfigs_partition.assignment.strategy) such as @javadoc[CooperativeStickyAssignor](org.apache.kafka.clients.consumer.CooperativeStickyAssignor) is recommended. They were introduced in [Kafka 3.0](https://kafka.apache.org/33/documentation.html#upgrade_300_notable). Please check the [Kafka upgrade guide](https://cwiki.apache.org/confluence/display/KAFKA/KIP-429:+Kafka+Consumer+Incremental+Rebalance+Protocol#KIP429:KafkaConsumerIncrementalRebalanceProtocol-Consumer) before changing it.
 
 reference.conf (HOCON)
 : @@ snip [snip](/core/src/main/resources/reference.conf) { #consumer-settings }

--- a/java-tests/src/test/java/docs/javadsl/ConsumerSettingsTest.java
+++ b/java-tests/src/test/java/docs/javadsl/ConsumerSettingsTest.java
@@ -14,8 +14,11 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.kafka.ConsumerSettings;
@@ -45,5 +48,20 @@ public class ConsumerSettingsTest {
                 DiscoverySupport.consumerBootstrapServers(consumerConfig, system));
     // #discovery-settings
     TestKit.shutdownActorSystem(system);
+  }
+
+  @Test
+  public void setAssignor() throws Exception {
+    ActorSystem system = ActorSystem.create("ConsumerSettingsTest");
+    ConsumerSettings<String, String> settings =
+        ConsumerSettings.create(system, new StringDeserializer(), new StringDeserializer())
+            .withPartitionAssignmentStrategies(
+                new String[] {
+                  org.apache.kafka.clients.consumer.CooperativeStickyAssignor.class.getName(),
+                  org.apache.kafka.clients.consumer.StickyAssignor.class.getName()
+                });
+    assertEquals(
+        "org.apache.kafka.clients.consumer.CooperativeStickyAssignor,org.apache.kafka.clients.consumer.StickyAssignor",
+        settings.getProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG));
   }
 }

--- a/tests/src/test/scala/org/apache/pekko/kafka/ConsumerSettingsSpec.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/ConsumerSettingsSpec.scala
@@ -19,6 +19,7 @@ import pekko.actor.ActorSystem
 import pekko.kafka.tests.scaladsl.LogCapturing
 import pekko.testkit.TestKit
 import com.typesafe.config.ConfigFactory
+import org.apache.kafka.clients.consumer.{ ConsumerConfig, CooperativeStickyAssignor }
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.serialization.{ ByteArrayDeserializer, StringDeserializer }
 import org.scalatest.OptionValues
@@ -102,6 +103,43 @@ class ConsumerSettingsSpec
         .getConfig("pekko.kafka.consumer")
       val settings = ConsumerSettings(conf, None, Some(new ByteArrayDeserializer))
       settings.getProperty("bootstrap.servers") should ===("localhost:9092")
+    }
+
+    "handle withPartitionAssignmentStrategies" in {
+      val conf = ConfigFactory
+        .parseString(
+          """
+        pekko.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
+        pekko.kafka.consumer.kafka-clients.key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+        pekko.kafka.consumer.kafka-clients.value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+        pekko.kafka.consumer.kafka-clients.client.id = client1
+        """)
+        .withFallback(ConfigFactory.load())
+        .getConfig("pekko.kafka.consumer")
+      val settings = ConsumerSettings(conf, None, None)
+        .withPartitionAssignmentStrategies(List(
+          classOf[org.apache.kafka.clients.consumer.CooperativeStickyAssignor].getName,
+          classOf[org.apache.kafka.clients.consumer.StickyAssignor].getName)
+        )
+      settings.getProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG) should ===(
+        "org.apache.kafka.clients.consumer.CooperativeStickyAssignor,org.apache.kafka.clients.consumer.StickyAssignor")
+    }
+
+    "handle withPartitionAssignmentStrategyCooperativeStickyAssignor" in {
+      val conf = ConfigFactory
+        .parseString(
+          """
+        pekko.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
+        pekko.kafka.consumer.kafka-clients.key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+        pekko.kafka.consumer.kafka-clients.value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+        pekko.kafka.consumer.kafka-clients.client.id = client1
+        """)
+        .withFallback(ConfigFactory.load())
+        .getConfig("pekko.kafka.consumer")
+      val settings = ConsumerSettings(conf, None, None)
+        .withPartitionAssignmentStrategyCooperativeStickyAssignor()
+      settings.getProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG) should ===(
+        "org.apache.kafka.clients.consumer.CooperativeStickyAssignor")
     }
 
     "filter passwords from kafka-clients properties" in {


### PR DESCRIPTION
Ports https://github.com/akka/alpakka-kafka/pull/1598 which is now Apache 2.0.

I've made some additions/changes because I think the original PR is not very Scala idiomatic.