### PR TITLE
Upgrade kafka-clients to 4.2.0 and fix deprecated API usage

### DIFF
--- a/benchmarks/src/main/scala/org/apache/pekko/kafka/benchmarks/KafkaTransactionBenchmarks.scala
+++ b/benchmarks/src/main/scala/org/apache/pekko/kafka/benchmarks/KafkaTransactionBenchmarks.scala
@@ -49,7 +49,7 @@ object KafkaTransactionBenchmarks extends LazyLogging {
       accumulatedMsgCount = 0
       val offsetMap = Map(new TopicPartition(fixture.sourceTopic, 0) -> new OffsetAndMetadata(lastProcessedOffset))
       logger.debug("Committing offset " + offsetMap.head._2.offset())
-      producer.sendOffsetsToTransaction(offsetMap.asJava, new ConsumerGroupMetadata(fixture.groupId))
+      producer.sendOffsetsToTransaction(offsetMap.asJava, consumer.groupMetadata())
       producer.commitTransaction()
     }
 

--- a/core/src/main/scala/org/apache/pekko/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/ConsumerMessage.scala
@@ -21,7 +21,7 @@ import org.apache.pekko
 import pekko.Done
 import pekko.annotation.{ DoNotInherit, InternalApi }
 import pekko.kafka.internal.{ CommittableOffsetBatchImpl, CommittedMarker }
-import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, ConsumerRecord }
 import org.apache.kafka.common.TopicPartition
 
 import scala.concurrent.Future
@@ -134,15 +134,17 @@ object ConsumerMessage {
 
   private[kafka] object PartitionOffsetCommittedMarker {
     def apply(key: GroupTopicPartition, offset: Long,
-        committedMarker: CommittedMarker, fromPartitionedSource: Boolean): PartitionOffsetCommittedMarker =
-      new PartitionOffsetCommittedMarker(key, offset, committedMarker, fromPartitionedSource)
+        committedMarker: CommittedMarker, fromPartitionedSource: Boolean,
+        consumerGroupMetadata: ConsumerGroupMetadata): PartitionOffsetCommittedMarker =
+      new PartitionOffsetCommittedMarker(key, offset, committedMarker, fromPartitionedSource, consumerGroupMetadata)
   }
 
   @InternalApi private[kafka] final class PartitionOffsetCommittedMarker(
       override val key: GroupTopicPartition,
       override val offset: Long,
       private[kafka] val committedMarker: CommittedMarker,
-      private[kafka] val fromPartitionedSource: Boolean) extends PartitionOffset(key, offset)
+      private[kafka] val fromPartitionedSource: Boolean,
+      private[kafka] val consumerGroupMetadata: ConsumerGroupMetadata) extends PartitionOffset(key, offset)
 
   /**
    * groupId, topic, partition key for an offset position.

--- a/core/src/main/scala/org/apache/pekko/kafka/internal/BaseSingleSourceLogic.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/BaseSingleSourceLogic.scala
@@ -76,6 +76,7 @@ import scala.concurrent.{ ExecutionContext, Future }
       // might be more than one in flight when we assign/revoke tps
       if (msg.requestId == requestId)
         requested = false
+      msg.groupMetadata.foreach(onGroupMetadata)
       buffer = buffer ++ msg.messages
       pump()
     case (_, Status.Failure(e)) =>
@@ -83,6 +84,8 @@ import scala.concurrent.{ ExecutionContext, Future }
     case (_, Terminated(ref)) if ref == consumerActor =>
       failStage(new ConsumerFailed())
   }
+
+  protected def onGroupMetadata(metadata: org.apache.kafka.clients.consumer.ConsumerGroupMetadata): Unit = ()
 
   protected def createConsumerActor(): ActorRef
 

--- a/core/src/main/scala/org/apache/pekko/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/KafkaConsumerActor.scala
@@ -43,7 +43,6 @@ import org.apache.kafka.common.errors.{
 }
 import org.apache.kafka.common.{ Metric, MetricName, TopicPartition }
 
-import scala.annotation.nowarn
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
@@ -87,7 +86,8 @@ import scala.util.control.NonFatal
     // responses
     final case class Assigned(partition: List[TopicPartition]) extends NoSerializationVerificationNeeded
     final case class Revoked(partition: List[TopicPartition]) extends NoSerializationVerificationNeeded
-    final case class Messages[K, V](requestId: Int, messages: Iterator[ConsumerRecord[K, V]])
+    final case class Messages[K, V](requestId: Int, messages: Iterator[ConsumerRecord[K, V]],
+        groupMetadata: Option[ConsumerGroupMetadata] = None)
         extends NoSerializationVerificationNeeded
     final case class ConsumerMetrics(metrics: Map[MetricName, Metric]) extends NoSerializationVerificationNeeded {
       def getMetrics: java.util.Map[MetricName, Metric] = metrics.asJava
@@ -449,7 +449,6 @@ import scala.util.control.NonFatal
     progressTracker
   }
 
-  @nowarn("msg=deprecated")
   override def postStop(): Unit = {
     // reply to outstanding requests is important if the actor is restarted
     requests.foreach {
@@ -457,7 +456,7 @@ import scala.util.control.NonFatal
         ref ! Messages(req.requestId, Iterator.empty)
     }
     partitionAssignmentHandler.postStop()
-    consumer.close(settings.getCloseTimeout)
+    consumer.close(CloseOptions.timeout(settings.getCloseTimeout))
     super.postStop()
   }
 
@@ -643,7 +642,7 @@ import scala.util.control.NonFatal
           }
           val messages = b.result().iterator
           if (messages.nonEmpty) {
-            stageActorRef ! Messages(req.requestId, messages)
+            stageActorRef ! Messages(req.requestId, messages, Some(consumer.groupMetadata()))
             requests -= stageActorRef
           }
       }

--- a/core/src/main/scala/org/apache/pekko/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/MessageBuilder.scala
@@ -27,7 +27,7 @@ import pekko.kafka.ConsumerMessage.{
   TransactionalMessage,
   _
 }
-import org.apache.kafka.clients.consumer.{ ConsumerRecord, OffsetAndMetadata }
+import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, ConsumerRecord, OffsetAndMetadata }
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.OffsetFetchResponse
 
@@ -57,6 +57,8 @@ private[kafka] trait TransactionalMessageBuilderBase[K, V, Msg] extends MessageB
   def onMessage(consumerMessage: ConsumerRecord[K, V]): Unit
 
   def fromPartitionedSource: Boolean
+
+  def consumerGroupMetadata: ConsumerGroupMetadata
 }
 
 /** Internal API */
@@ -72,7 +74,8 @@ private[kafka] trait TransactionalMessageBuilder[K, V]
         partition = rec.partition),
       offset = rec.offset,
       committedMarker,
-      fromPartitionedSource)
+      fromPartitionedSource,
+      consumerGroupMetadata)
     ConsumerMessage.TransactionalMessage(rec, offset)
   }
 }
@@ -90,7 +93,8 @@ private[kafka] trait TransactionalOffsetContextBuilder[K, V]
         partition = rec.partition),
       offset = rec.offset,
       committedMarker,
-      fromPartitionedSource)
+      fromPartitionedSource,
+      consumerGroupMetadata)
     (rec, offset)
   }
 }

--- a/core/src/main/scala/org/apache/pekko/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/SingleSourceLogic.scala
@@ -62,7 +62,7 @@ import scala.concurrent.{ Future, Promise }
       complete(shape.out)
     }
     sourceActor.become(shuttingDownReceive.orElse {
-      case (_, Messages(requestId, messages)) =>
+      case (_, Messages(requestId, messages, _)) =>
         // Prevent stage failure during shutdown by ignoring Messages
         if (messages.hasNext)
           log.debug("Unexpected `Messages` received with requestId={} and a non-empty message iterator: {}",

--- a/core/src/main/scala/org/apache/pekko/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/SubSourceLogic.scala
@@ -429,6 +429,7 @@ private abstract class SubSourceStageLogic[K, V, Msg](
   protected def messageHandling: PartialFunction[(ActorRef, Any), Unit] = {
     case (_, msg: KafkaConsumerActor.Internal.Messages[K @unchecked, V @unchecked]) =>
       requested = false
+      msg.groupMetadata.foreach(onGroupMetadata)
       buffer = buffer ++ msg.messages
       pump()
     case (_, Status.Failure(e)) =>
@@ -436,6 +437,8 @@ private abstract class SubSourceStageLogic[K, V, Msg](
     case (_, Terminated(ref)) if ref == consumerActor =>
       failStage(new ConsumerFailed)
   }
+
+  protected def onGroupMetadata(metadata: org.apache.kafka.clients.consumer.ConsumerGroupMetadata): Unit = ()
 
   protected def onDownstreamFinishSubSourceCancellationStrategy(): SubSourceCancellationStrategy =
     if (buffer.hasNext) {

--- a/core/src/main/scala/org/apache/pekko/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/TransactionalProducerStage.scala
@@ -75,6 +75,7 @@ private object TransactionalProducerStage {
 
     def group: String = head.key.groupId
     def committedMarker: CommittedMarker = head.committedMarker
+    def groupMetadata: ConsumerGroupMetadata = head.consumerGroupMetadata
 
     def offsetMap(): Map[TopicPartition, OffsetAndMetadata] = offsets.map {
       case (gtp, offset) => new TopicPartition(gtp.topic, gtp.partition) -> new OffsetAndMetadata(offset + 1)
@@ -247,7 +248,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
       group,
       batch.offsets)
     val offsetMap = batch.offsetMap()
-    producer.sendOffsetsToTransaction(offsetMap.asJava, new ConsumerGroupMetadata(group))
+    producer.sendOffsetsToTransaction(offsetMap.asJava, batch.groupMetadata)
     producer.commitTransaction()
     log.debug("Committed transaction for transactional id '{}' consumer group '{}' with offsets: {}",
       transactionalId,

--- a/core/src/main/scala/org/apache/pekko/kafka/internal/TransactionalSources.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/TransactionalSources.scala
@@ -149,7 +149,9 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
 
   override def consumerGroupMetadata: ConsumerGroupMetadata =
     currentGroupMetadata.getOrElse(
-      throw new IllegalStateException(s"Consumer group metadata not yet available for group $groupId"))
+      throw new IllegalStateException(
+        s"Consumer group metadata not yet available for group $groupId. " +
+        "Metadata is populated on the first poll delivering messages from the consumer."))
 
   override lazy val committedMarker: CommittedMarker = {
     val ec = materializer.executionContext
@@ -385,7 +387,9 @@ private final class TransactionalSubSourceStageLogic[K, V](
 
   override def consumerGroupMetadata: ConsumerGroupMetadata =
     currentGroupMetadata.getOrElse(
-      throw new IllegalStateException(s"Consumer group metadata not yet available for group $groupId"))
+      throw new IllegalStateException(
+        s"Consumer group metadata not yet available for group $groupId. " +
+        "Metadata is populated on the first poll delivering messages from the consumer."))
 
   override def onMessage(rec: ConsumerRecord[K, V]): Unit =
     inFlightRecords.add(Map(new TopicPartition(rec.topic(), rec.partition()) -> rec.offset()))

--- a/core/src/main/scala/org/apache/pekko/kafka/internal/TransactionalSources.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/TransactionalSources.scala
@@ -32,7 +32,7 @@ import pekko.stream.SourceShape
 import pekko.stream.scaladsl.Source
 import pekko.stream.stage.{ AsyncCallback, GraphStageLogic }
 import pekko.util.Timeout
-import org.apache.kafka.clients.consumer.{ ConsumerConfig, ConsumerRecord, OffsetAndMetadata }
+import org.apache.kafka.clients.consumer.{ ConsumerConfig, ConsumerGroupMetadata, ConsumerRecord, OffsetAndMetadata }
 import org.apache.kafka.common.{ IsolationLevel, TopicPartition }
 
 import scala.concurrent.duration.FiniteDuration
@@ -141,6 +141,15 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
   }
 
   override val groupId: String = consumerSettings.properties(ConsumerConfig.GROUP_ID_CONFIG)
+
+  private var currentGroupMetadata: Option[ConsumerGroupMetadata] = None
+
+  override protected def onGroupMetadata(metadata: ConsumerGroupMetadata): Unit =
+    currentGroupMetadata = Some(metadata)
+
+  override def consumerGroupMetadata: ConsumerGroupMetadata =
+    currentGroupMetadata.getOrElse(
+      throw new IllegalStateException(s"Consumer group metadata not yet available for group $groupId"))
 
   override lazy val committedMarker: CommittedMarker = {
     val ec = materializer.executionContext
@@ -368,6 +377,15 @@ private final class TransactionalSubSourceStageLogic[K, V](
   private val inFlightRecords = InFlightRecords.empty
 
   override def groupId: String = consumerSettings.properties(ConsumerConfig.GROUP_ID_CONFIG)
+
+  private var currentGroupMetadata: Option[ConsumerGroupMetadata] = None
+
+  override protected def onGroupMetadata(metadata: ConsumerGroupMetadata): Unit =
+    currentGroupMetadata = Some(metadata)
+
+  override def consumerGroupMetadata: ConsumerGroupMetadata =
+    currentGroupMetadata.getOrElse(
+      throw new IllegalStateException(s"Consumer group metadata not yet available for group $groupId"))
 
   override def onMessage(rec: ConsumerRecord[K, V]): Unit =
     inFlightRecords.add(Map(new TopicPartition(rec.topic(), rec.partition()) -> rec.offset()))

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -22,7 +22,7 @@ object Versions {
   val pekkoConnectorsKafkaVersionForDocs = "current"
   val pekkoManagementVersionForDocs = "current"
 
-  val kafkaVersion = "4.1.2"
+  val kafkaVersion = "4.2.0"
   val KafkaVersionForDocs = "37"
 
   val mockitoVersion = "5.23.0"

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -27,7 +27,7 @@ import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.ConsumerGroupState;
+import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.pekko.Done;
@@ -153,7 +153,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
         groupId,
         group -> {
           try {
-            return group.state() == ConsumerGroupState.STABLE && predicate.test(group.members());
+            return group.groupState() == GroupState.STABLE && predicate.test(group.members());
           } catch (Exception ex) {
             return false;
           }

--- a/testkit/src/main/scala/org/apache/pekko/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/org/apache/pekko/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -33,10 +33,9 @@ import pekko.stream.testkit.scaladsl.TestSink
 import pekko.testkit.TestKit
 import org.apache.kafka.clients.admin._
 import org.apache.kafka.clients.producer.{ Producer => KProducer, ProducerRecord }
-import org.apache.kafka.common.ConsumerGroupState
+import org.apache.kafka.common.GroupState
 import org.slf4j.{ Logger, LoggerFactory }
 
-import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future }
@@ -120,10 +119,9 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
    *
    * If the predicate does not hold after configured amount of time, throws an exception.
    */
-  @nowarn("cat=deprecation")
   def waitUntilConsumerSummary(groupId: String)(predicate: PartialFunction[List[MemberDescription], Boolean]): Unit =
     waitUntilConsumerGroup(groupId) { group =>
-      group.state() == ConsumerGroupState.STABLE &&
+      group.groupState() == GroupState.STABLE &&
       Try(predicate(group.members().asScala.toList)).getOrElse(false)
     }
 

--- a/tests/src/test/scala/org/apache/pekko/kafka/internal/ConsumerDummy.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/internal/ConsumerDummy.scala
@@ -98,7 +98,8 @@ abstract class ConsumerDummy[K, V] extends Consumer[K, V] {
   override def endOffsets(partitions: java.util.Collection[TopicPartition],
       timeout: java.time.Duration): java.util.Map[TopicPartition, java.lang.Long] = ???
   override def poll(timeout: java.time.Duration): ConsumerRecords[K, V] = ???
-  override def groupMetadata(): ConsumerGroupMetadata = ???
+  @scala.annotation.nowarn("msg=deprecated")
+  override def groupMetadata(): ConsumerGroupMetadata = new ConsumerGroupMetadata("unknown")
   override def enforceRebalance(): Unit = ???
   override def currentLag(partition: TopicPartition): java.util.OptionalLong = ???
 

--- a/tests/src/test/scala/org/apache/pekko/kafka/internal/ConsumerDummy.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/internal/ConsumerDummy.scala
@@ -99,7 +99,7 @@ abstract class ConsumerDummy[K, V] extends Consumer[K, V] {
       timeout: java.time.Duration): java.util.Map[TopicPartition, java.lang.Long] = ???
   override def poll(timeout: java.time.Duration): ConsumerRecords[K, V] = ???
   @scala.annotation.nowarn("msg=deprecated")
-  override def groupMetadata(): ConsumerGroupMetadata = new ConsumerGroupMetadata("unknown")
+  override def groupMetadata(): ConsumerGroupMetadata = new ConsumerGroupMetadata("dummy-consumer-group")
   override def enforceRebalance(): Unit = ???
   override def currentLag(partition: TopicPartition): java.util.OptionalLong = ???
 

--- a/tests/src/test/scala/org/apache/pekko/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/internal/ProducerSpec.scala
@@ -48,6 +48,12 @@ import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success, Try }
 
+private[internal] object ProducerSpec {
+  val group = "group"
+  @scala.annotation.nowarn("msg=deprecated")
+  val testGroupMetadata = new ConsumerGroupMetadata(group)
+}
+
 class ProducerSpec(_system: ActorSystem)
     extends TestKit(_system)
     with AnyFlatSpecLike
@@ -65,10 +71,7 @@ class ProducerSpec(_system: ActorSystem)
   override def afterAll(): Unit = shutdown(system)
 
   implicit val ec: ExecutionContext = _system.dispatcher
-
-  private val group = "group"
-  @scala.annotation.nowarn("msg=deprecated")
-  private val testGroupMetadata = new ConsumerGroupMetadata(group)
+  import ProducerSpec._
 
   type K = String
   type V = String
@@ -641,7 +644,7 @@ class ProducerMock[K, V](handler: ProducerMock.Handler[K, V])(implicit ec: Execu
     val offsets = Map(new TopicPartition(po.key.topic, po.key.partition) -> new OffsetAndMetadata(po.offset + 1)).asJava
     val expectedMeta = po match {
       case m: ConsumerMessage.PartitionOffsetCommittedMarker => m.consumerGroupMetadata
-      case _                                                 => testGroupMetadata
+      case _                                                 => ProducerSpec.testGroupMetadata
     }
     inOrder.verify(mock).sendOffsetsToTransaction(offsets, expectedMeta)
     inOrder.verify(mock).commitTransaction()
@@ -653,7 +656,7 @@ class ProducerMock[K, V](handler: ProducerMock.Handler[K, V])(implicit ec: Execu
     val offsets = Map(new TopicPartition(po.key.topic, po.key.partition) -> new OffsetAndMetadata(po.offset + 1)).asJava
     val expectedMeta = po match {
       case m: ConsumerMessage.PartitionOffsetCommittedMarker => m.consumerGroupMetadata
-      case _                                                 => testGroupMetadata
+      case _                                                 => ProducerSpec.testGroupMetadata
     }
     inOrder.verify(mock).sendOffsetsToTransaction(offsets, expectedMeta)
     inOrder.verify(mock).commitTransaction()

--- a/tests/src/test/scala/org/apache/pekko/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/internal/ProducerSpec.scala
@@ -67,6 +67,8 @@ class ProducerSpec(_system: ActorSystem)
   implicit val ec: ExecutionContext = _system.dispatcher
 
   private val group = "group"
+  @scala.annotation.nowarn("msg=deprecated")
+  private val testGroupMetadata = new ConsumerGroupMetadata(group)
 
   type K = String
   type V = String
@@ -86,7 +88,8 @@ class ProducerSpec(_system: ActorSystem)
       PartitionOffsetCommittedMarker(consumerMessage.key,
         consumerMessage.offset,
         committer,
-        fromPartitionedSource = false)
+        fromPartitionedSource = false,
+        testGroupMetadata)
     ProducerMessage.Message(
       tuple._1,
       partitionOffsetCommittedMarker)
@@ -636,7 +639,11 @@ class ProducerMock[K, V](handler: ProducerMock.Handler[K, V])(implicit ec: Execu
   def verifyTxCommit(po: ConsumerMessage.PartitionOffset) = {
     val inOrder = Mockito.inOrder(mock)
     val offsets = Map(new TopicPartition(po.key.topic, po.key.partition) -> new OffsetAndMetadata(po.offset + 1)).asJava
-    inOrder.verify(mock).sendOffsetsToTransaction(offsets, new ConsumerGroupMetadata(po.key.groupId))
+    val expectedMeta = po match {
+      case m: ConsumerMessage.PartitionOffsetCommittedMarker => m.consumerGroupMetadata
+      case _                                                 => testGroupMetadata
+    }
+    inOrder.verify(mock).sendOffsetsToTransaction(offsets, expectedMeta)
     inOrder.verify(mock).commitTransaction()
     inOrder.verify(mock).beginTransaction()
   }
@@ -644,7 +651,11 @@ class ProducerMock[K, V](handler: ProducerMock.Handler[K, V])(implicit ec: Execu
   def verifyTxCommitWhenShutdown(po: ConsumerMessage.PartitionOffset) = {
     val inOrder = Mockito.inOrder(mock)
     val offsets = Map(new TopicPartition(po.key.topic, po.key.partition) -> new OffsetAndMetadata(po.offset + 1)).asJava
-    inOrder.verify(mock).sendOffsetsToTransaction(offsets, new ConsumerGroupMetadata(po.key.groupId))
+    val expectedMeta = po match {
+      case m: ConsumerMessage.PartitionOffsetCommittedMarker => m.consumerGroupMetadata
+      case _                                                 => testGroupMetadata
+    }
+    inOrder.verify(mock).sendOffsetsToTransaction(offsets, expectedMeta)
     inOrder.verify(mock).commitTransaction()
   }
 


### PR DESCRIPTION
## Summary

Upgrades `kafka-clients` from 4.1.2 to 4.2.0 and fixes all compilation issues caused by newly deprecated/removed APIs.

## Changes

### Version bump
- `kafkaVersion = "4.1.2"` → `"4.2.0"` in `project/Versions.scala`

### ConsumerGroupMetadata constructors (deprecated with `forRemoval=true` in 4.2.0)
Instead of creating `new ConsumerGroupMetadata(groupId)` in `TransactionalProducerStage`, the actual `ConsumerGroupMetadata` is now threaded from the Kafka consumer through the message pipeline:
- Added `groupMetadata: Option[ConsumerGroupMetadata]` to `KafkaConsumerActor.Internal.Messages`
- `KafkaConsumerActor` includes `consumer.groupMetadata()` when sending non-empty messages
- Added `onGroupMetadata` hook to `BaseSingleSourceLogic` and `SubSourceLogic`
- Added `consumerGroupMetadata: ConsumerGroupMetadata` abstract method to `TransactionalMessageBuilderBase`
- `TransactionalSourceLogic` and `TransactionalSubSourceStageLogic` track the current group metadata
- Added `consumerGroupMetadata` field to `PartitionOffsetCommittedMarker`
- `TransactionalProducerStage.commitTransaction` now uses `batch.groupMetadata` directly

This is a proper fix (not just suppression): transactions now use the actual consumer's group metadata (including generation ID and member ID), which provides proper zombie-fencing semantics for EOS.

### `consumer.close(Duration)` (deprecated)
Replaced with `consumer.close(CloseOptions.timeout(duration))` in `KafkaConsumerActor.postStop`; removed now-unneeded `@nowarn` annotation.

### `ConsumerGroupDescription.state()` / `ConsumerGroupState` (deprecated since 4.0, `forRemoval=true`)
Replaced with `groupState()` / `GroupState.STABLE` in both `KafkaSpec.scala` and `BaseKafkaTest.java`.

### Benchmark
Replaced `new ConsumerGroupMetadata(fixture.groupId)` with `consumer.groupMetadata()` (the fixture has a real `KafkaConsumer` reference).

### Test infrastructure
`ConsumerDummy.groupMetadata()` now returns a non-throwing stub value. A `@nowarn("msg=deprecated")` annotation is used here since it's a mock consumer without a real Kafka connection, making the deprecated constructor the only option in this context.