### PR TITLE
Add -Yfuture-lazy-vals for Scala 3.3.x builds

### DIFF
--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -94,7 +94,7 @@ object ProjectSettings extends AutoPlugin {
       else Seq.empty
     },
     scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals")
+      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals", "-release:17")
       else Seq.empty
     },
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -93,6 +93,10 @@ object ProjectSettings extends AutoPlugin {
       if (insideCI.value && !Nightly && scalaVersion.value.startsWith("2.")) Seq("-Werror")
       else Seq.empty
     },
+    scalacOptions ++= {
+      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals")
+      else Seq.empty
+    },
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
       "-Wconf:cat=scaladoc:i",
       "-doc-title",


### PR DESCRIPTION
### Motivation

The Scala 3.3.8 compiler introduced the `-Yfuture-lazy-vals` flag ([scala/scala3-lts#637](https://github.com/scala/scala3-lts/pull/637)) to optionally use `VarHandle` instead of `sun.misc.Unsafe` for lazy val implementation. This prepares libraries for upcoming JDK releases that restrict `sun.misc.Unsafe` access.

### Modification

Add `-Yfuture-lazy-vals` to scalacOptions, conditionally applied only for Scala 3.3.x.

### Result

Scala 3.3.x build uses the future-proof `VarHandle`-based lazy val implementation, compatible with all JDK 9+ versions including future releases that restrict `sun.misc.Unsafe`.

### References

Refs scala/scala3-lts#637
Refs apache/pekko#3059