### PR TITLE
Fix flaky TransactionsSourceSpec: increase idle timeout, completedWithTimeout threshold, and Await timeout

### DIFF
--- a/int-tests/src/test/scala/org/apache/pekko/kafka/TransactionsSourceSpec.scala
+++ b/int-tests/src/test/scala/org/apache/pekko/kafka/TransactionsSourceSpec.scala
@@ -26,7 +26,6 @@ import pekko.stream._
 import pekko.stream.scaladsl.{ Flow, Keep, RestartSource, Sink }
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.scalatest.concurrent.PatienceConfiguration.Interval
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -95,12 +94,12 @@ class TransactionsSourceSpec
               sourceTopic,
               sinkTopic,
               transactionId,
-              10.seconds,
+              30.seconds,
               Some(restartAfter),
               Some(maxRestarts))
               .recover {
                 case e: TimeoutException =>
-                  if (completedWithTimeout.incrementAndGet() > 10)
+                  if (completedWithTimeout.incrementAndGet() > (consumers * 10))
                     "no more messages to copy"
                   else
                     throw new Error("Continue restarting copy stream")
@@ -120,10 +119,6 @@ class TransactionsSourceSpec
 
       val probeConsumerGroup = createGroupId(2)
 
-      eventually(Interval(2.seconds)) {
-        completedCopy.get() should be < consumers
-      }
-
       val consumer = offsetValueSource(probeConsumerSettings(probeConsumerGroup), sinkTopic)
         .take(elements.toLong)
         .alsoTo(
@@ -138,7 +133,7 @@ class TransactionsSourceSpec
         .filter(_._2 != "no-more-elements")
         .runWith(Sink.seq)
 
-      val values = Await.result(consumer, 10.minutes)
+      val values = Await.result(consumer, 15.minutes)
 
       val expected = (1 to elements).map(_.toString)
 


### PR DESCRIPTION
fixes #392

The test `must provide consistency when multiple transactional streams are being restarted` was intermittently timing out because copy streams terminated before all 100k messages were copied to the sink topic.

## Root causes

- **`completedWithTimeout` threshold too low and not stream-proportional.** The counter is shared across all 3 copy streams. Idle timeouts fire spuriously during Kafka consumer group rebalancing (partition reassignment stalls the stream for >10s). With 3 streams, 3 brokers, and frequent forced restarts, accumulating 11 spurious timeouts before copy completes is easy. Once the threshold is crossed, all subsequent timeouts cause streams to succeed and terminate — leaving the probe consumer waiting for messages that will never arrive.

- **`idleTimeout(10.seconds)` too short for rebalance windows.** A 3-broker rebalance can easily take >10s, making spurious timeouts near-certain on each restart cycle.

- **`eventually` check was a no-op.** `completedCopy.get() should be < consumers` is trivially `0 < 3` on entry and always passes immediately.

## Changes

- `idleTimeout`: `10.seconds` → `30.seconds` — covers typical rebalance duration so idle only fires when genuinely idle
- `completedWithTimeout` threshold: `> 10` → `> (consumers * 10)` — scales with the number of concurrent streams (30 for 3 consumers)
- `Await.result` timeout: `10.minutes` → `15.minutes` — accounts for up to ~5 min of legitimate idle cycling after copy completes (~30 threshold / 3 concurrent streams × 30s each)
- Removed the no-op `eventually` block and its unused `PatienceConfiguration.Interval` import