### PR TITLE
chore: suppress sbt lint warnings for intentionally used keys

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,6 +141,7 @@ lazy val docs = project
     Compile / paradox / name := "Pekko",
     makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
     previewPath := (Paradox / siteSubdirName).value,
+    Global / excludeLintKeys += previewPath,
     Global / pekkoParadoxIncubatorNotice := None,
     Preprocess / siteSubdirName := s"api/pekko-connectors-kafka/${projectInfoVersion.value}",
     Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -144,4 +144,7 @@ object ProjectSettings extends AutoPlugin {
 
   override lazy val buildSettings = Seq(
     dynverSonatypeSnapshots := true)
+
+  override def globalSettings =
+    Seq(excludeLintKeys ++= Set(mimaReportSignatureProblems, projectInfoVersion))
 }


### PR DESCRIPTION
## Summary
- Suppress false-positive sbt lint warnings for keys that are legitimately used in build configuration
- Add `globalSettings` override to exclude `mimaReportSignatureProblems` and `projectInfoVersion` from lint checks
- Add `Global / excludeLintKeys` for `previewPath` in docs project

## Test plan
- [x] `sbt compile` produces no warnings
- [x] `sbt reload` produces no lint warnings
- [x] `sbt lintUnused` passes cleanly