### PR TITLE
increase timeout for kafka docker container startup

### DIFF
--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/PekkoConnectorsKafkaContainer.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/PekkoConnectorsKafkaContainer.java
@@ -17,6 +17,7 @@ package org.apache.pekko.kafka.testkit.internal;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.ContainerNetwork;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -79,6 +80,9 @@ public class PekkoConnectorsKafkaContainer extends GenericContainer<PekkoConnect
     super.withNetwork(Network.SHARED);
 
     withExposedPorts(KAFKA_PORT);
+
+    // The default startup timeout of 1 minute is not enough for Kafka to start reliably in CI
+    withStartupTimeout(Duration.ofMinutes(3));
 
     withBrokerNum(this.brokerNum);
 


### PR DESCRIPTION
see #321

https://github.com/apache/pekko-connectors-kafka/actions/runs/27625225143/job/81687312177

```
[info] docs.scaladsl.SchemaRegistrySerializationSpec *** ABORTED *** (1 minute)
[info]   java.lang.RuntimeException: java.util.concurrent.ExecutionException: org.testcontainers.containers.ContainerLaunchException: Container startup failed for image confluentinc/cp-kafka:7.9.2
[info]   at org.apache.pekko.kafka.testkit.internal.KafkaContainerCluster.start(KafkaContainerCluster.java:226)
[info]   at org.apache.pekko.kafka.testkit.internal.TestcontainersKafka$Spec.startCluster(TestcontainersKafka.scala:104)
[info]   at org.apache.pekko.kafka.testkit.internal.TestcontainersKafka$Spec.startCluster$(TestcontainersKafka.scala:28)
[info]   at docs.scaladsl.SchemaRegistrySerializationSpec.startCluster(SchemaRegistrySerializationSpec.scala:48)
[info]   at org.apache.pekko.kafka.testkit.internal.TestcontainersKafka$Spec.startCluster(TestcontainersKafka.scala:75)
[info]   at org.apache.pekko.kafka.testkit.internal.TestcontainersKafka$Spec.startCluster$(TestcontainersKafka.scala:28)
[info]   at docs.scaladsl.SchemaRegistrySerializationSpec.startCluster(SchemaRegistrySerializationSpec.scala:48)
[info]   at org.apache.pekko.kafka.testkit.scaladsl.TestcontainersKafkaPerClassLike.setUp(TestcontainersKafkaPerClassLike.scala:25)
[info]   at org.apache.pekko.kafka.testkit.scaladsl.TestcontainersKafkaPerClassLike.setUp$(TestcontainersKafkaPerClassLike.scala:23)
[info]   at docs.scaladsl.SchemaRegistrySerializationSpec.setUp(SchemaRegistrySerializationSpec.scala:48)
[info]   at org.apache.pekko.kafka.testkit.internal.TestFrameworkInterface$Scalatest.beforeAll(TestFrameworkInterface.scala:30)
[info]   at org.apache.pekko.kafka.testkit.internal.TestFrameworkInterface$Scalatest.beforeAll$(TestFrameworkInterface.scala:26)
[info]   at docs.scaladsl.DocsSpecBase.beforeAll(DocsSpecBase.scala:27)
[info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:212)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:217)
[info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:135)
[info]   at docs.scaladsl.DocsSpecBase.run(DocsSpecBase.scala:27)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:517)
[info]   at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
[info]   Cause: java.util.concurrent.ExecutionException: org.testcontainers.containers.ContainerLaunchException: Container startup failed for image confluentinc/cp-kafka:7.9.2
[info]   at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
[info]   at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2096)
[info]   at org.apache.pekko.kafka.testkit.internal.KafkaContainerCluster.start(KafkaContainerCluster.java:208)
[info]   at org.apache.pekko.kafka.testkit.internal.TestcontainersKafka$Spec.startCluster(TestcontainersKafka.scala:104)
[info]   at org.apache.pekko.kafka.testkit.internal.TestcontainersKafka$Spec.startCluster$(TestcontainersKafka.scala:28)
[info]   at docs.scaladsl.SchemaRegistrySerializationSpec.startCluster(SchemaRegistrySerializationSpec.scala:48)
[info]   at org.apache.pekko.kafka.testkit.internal.TestcontainersKafka$Spec.startCluster(TestcontainersKafka.scala:75)
[info]   at org.apache.pekko.kafka.testkit.internal.TestcontainersKafka$Spec.startCluster$(TestcontainersKafka.scala:28)
[info]   at docs.scaladsl.SchemaRegistrySerializationSpec.startCluster(SchemaRegistrySerializationSpec.scala:48)
[info]   at org.apache.pekko.kafka.testkit.scaladsl.TestcontainersKafkaPerClassLike.setUp(TestcontainersKafkaPerClassLike.scala:25)
[info]   at org.apache.pekko.kafka.testkit.scaladsl.TestcontainersKafkaPerClassLike.setUp$(TestcontainersKafkaPerClassLike.scala:23)
[info]   at docs.scaladsl.SchemaRegistrySerializationSpec.setUp(SchemaRegistrySerializationSpec.scala:48)
[info]   at org.apache.pekko.kafka.testkit.internal.TestFrameworkInterface$Scalatest.beforeAll(TestFrameworkInterface.scala:30)
[info]   at org.apache.pekko.kafka.testkit.internal.TestFrameworkInterface$Scalatest.beforeAll$(TestFrameworkInterface.scala:26)
[info]   at docs.scaladsl.DocsSpecBase.beforeAll(DocsSpecBase.scala:27)
[info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:212)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:217)
[info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:135)
[info]   at docs.scaladsl.DocsSpecBase.run(DocsSpecBase.scala:27)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:517)
[info]   at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
[info]   Cause: org.testcontainers.containers.ContainerLaunchException: Container startup failed for image confluentinc/cp-kafka:7.9.2
[info]   at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:351)
[info]   at org.apache.pekko.kafka.testkit.internal.PekkoConnectorsKafkaContainer.doStart(PekkoConnectorsKafkaContainer.java:194)
[info]   at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:322)
[info]   at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:787)
[info]   at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
[info]   Cause: org.rnorth.ducttape.RetryCountExceededException: Retry limit hit with exception
[info]   at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:88)
[info]   at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:336)
[info]   at org.apache.pekko.kafka.testkit.internal.PekkoConnectorsKafkaContainer.doStart(PekkoConnectorsKafkaContainer.java:194)
[info]   at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:322)
[info]   at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:787)
[info]   at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
[info]   Cause: org.testcontainers.containers.ContainerLaunchException: Could not create/start container
[info]   at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:556)
[info]   at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:346)
[info]   at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
[info]   at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:336)
[info]   at org.apache.pekko.kafka.testkit.internal.PekkoConnectorsKafkaContainer.doStart(PekkoConnectorsKafkaContainer.java:194)
[info]   at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:322)
[info]   at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:787)
[info]   at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
[info]   Cause: org.testcontainers.containers.ContainerLaunchException: Timed out waiting for container port to open (localhost ports: [32784, 32785] should be listening)
[info]   at org.testcontainers.containers.wait.strategy.HostPortWaitStrategy.waitUntilReady(HostPortWaitStrategy.java:112)
[info]   at org.testcontainers.containers.wait.strategy.AbstractWaitStrategy.waitUntilReady(AbstractWaitStrategy.java:52)
[info]   at org.testcontainers.containers.GenericContainer.waitUntilContainerStarted(GenericContainer.java:909)
[info]   at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:492)
[info]   at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:346)
[info]   at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
[info]   at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:336)
[info]   at org.apache.pekko.kafka.testkit.internal.PekkoConnectorsKafkaContainer.doStart(PekkoConnectorsKafkaContainer.java:194)
[info]   at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:322)
[info]   at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:787)
[info]   at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
```