### PR TITLE
fix: make -Yfuture-lazy-vals conditional for Scala 3.9+

### DIFF
--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -106,7 +106,9 @@ object ProjectSettings extends AutoPlugin {
           "-Wconf:msg=is not declared infix:s",
           "-Wconf:msg=auto insertion will be deprecated:s",
           "-Wconf:msg=Invalid message filter:s") ++
-        (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
+        (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9))
+           Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+         else Seq.empty)
       else Seq.empty
     },
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -96,7 +96,6 @@ object ProjectSettings extends AutoPlugin {
     scalacOptions ++= {
       if (scalaBinaryVersion.value == "3")
         Seq(
-          "-Yfuture-lazy-vals",
           "-release:17",
           "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
           "-Wconf:msg=is deprecated for wildcard arguments of types:s",
@@ -106,8 +105,8 @@ object ProjectSettings extends AutoPlugin {
           "-Wconf:msg=is no longer supported for vararg splices:s",
           "-Wconf:msg=is not declared infix:s",
           "-Wconf:msg=auto insertion will be deprecated:s",
-          "-Wconf:msg=Invalid message filter:s",
-          "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+          "-Wconf:msg=Invalid message filter:s") ++
+        (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
       else Seq.empty
     },
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(


### PR DESCRIPTION
### Motivation
Scala 3.9 removed the `-Yfuture-lazy-vals` compiler option as the future lazy vals behavior is now the default. Passing this flag on Scala 3.9+ causes a compilation error.

### Modification
Made `-Yfuture-lazy-vals` conditional on Scala minor version < 9 using `CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)`.

### Result
Project compiles on both Scala 3.3.x (which needs the flag) and Scala 3.9+ (which has the behavior by default).

### Tests
- `sbt "++3.9.0-RC1!; compile"` — no -Yfuture-lazy-vals error
- `sbt "++3.3.7!; compile"` — flag still applied

### References
- Part of the Scala 3.9 compatibility effort across all Pekko projects