### PR TITLE
fix: correct typos in kafka connector code and docs

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -79,7 +79,7 @@ pekko.kafka.consumer {
 
   # If offset commit requests are not completed within this timeout
   # the returned Future is completed `CommitTimeoutException`.
-  # The `Transactional.source` waits this ammount of time for the producer to mark messages as not
+  # The `Transactional.source` waits this amount of time for the producer to mark messages as not
   # being in flight anymore as well as waiting for messages to drain, when rebalance is triggered.
   commit-timeout = 15s
 

--- a/core/src/main/scala/org/apache/pekko/kafka/internal/ConsumerResetProtection.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/ConsumerResetProtection.scala
@@ -46,9 +46,9 @@ sealed trait ConsumerResetProtection {
 @InternalApi
 object ConsumerResetProtection {
   def apply[K, V](log: LoggingAdapter,
-      setttings: OffsetResetProtectionSettings,
+      settings: OffsetResetProtectionSettings,
       progress: () => ConsumerProgressTracking): ConsumerResetProtection = {
-    if (setttings.enable) new Impl(log, setttings, progress()) else ConsumerResetProtection.Noop
+    if (settings.enable) new Impl(log, settings, progress()) else ConsumerResetProtection.Noop
   }
 
   private object Noop extends ConsumerResetProtection {

--- a/core/src/main/scala/org/apache/pekko/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/TransactionalProducerStage.scala
@@ -185,7 +185,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
 
   /**
    * When using partitioned sources we extract the transactional id, group id, and topic partition information from
-   * the first message in order to define a `transacitonal.id` before constructing the [[org.apache.kafka.clients.producer.KafkaProducer]]
+   * the first message in order to define a `transactional.id` before constructing the [[org.apache.kafka.clients.producer.KafkaProducer]]
    */
   private def parseFirstMessage(msg: Envelope[K, V, P]): Boolean =
     producerAssignmentLifecycle match {

--- a/docs/src/main/paradox/transactions.md
+++ b/docs/src/main/paradox/transactions.md
@@ -17,7 +17,7 @@ A consumer group ID must be provided.
 
 Only use this source if you have the intention to connect it to a @apidoc[Transactional.flow](Transactional$) or @apidoc[Transactional.sink](Transactional$).
 
-<!-- TODO: uncomment when Transacitonal.partitionedSource is ready
+<!-- TODO: uncomment when Transactional.partitionedSource is ready
 ## Transactional Partitioned Source
 
 The @apidoc[Transactional.partitionedSource](Transactional$) is similar to the  `Transactional.source`.
@@ -79,7 +79,7 @@ Java
 : @@ snip [snip](/java-tests/src/test/java/docs/javadsl/TransactionsExampleTest.java) { #transactionalSink }
 
 
-<!-- TODO: uncomment when Transacitonal.partitionedSource is ready
+<!-- TODO: uncomment when Transactional.partitionedSource is ready
 ### Partitioned Source Example
 
 Scala

--- a/int-tests/src/test/resources/logback-test.xml
+++ b/int-tests/src/test/resources/logback-test.xml
@@ -27,7 +27,7 @@
     <logger name="org.apache.pekko" level="DEBUG"/>
     <logger name="org.apache.pekko.kafka" level="DEBUG"/>
     <logger name="org.apache.pekko.kafka.test.testcontainers.logs" level="INFO" />
-    <logger name="docs.scaladsl" levle="DEBUG"/>
+    <logger name="docs.scaladsl" level="DEBUG"/>
 
     <logger name="org.apache.zookeeper" level="WARN"/>
     <logger name="org.I0Itec.zkclient" level="WARN"/>

--- a/tests/src/test/scala/org/apache/pekko/kafka/internal/CommitCollectorStageSpec.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/internal/CommitCollectorStageSpec.scala
@@ -234,7 +234,7 @@ class CommitCollectorStageSpec(_system: ActorSystem)
 
         val commits = factory.committer.commits
 
-        (commits.last._2 shouldBe 10).withClue("last offset commit should be exactly the one preceeding the error")
+        (commits.last._2 shouldBe 10).withClue("last offset commit should be exactly the one preceding the error")
 
         control.shutdown().futureValue shouldBe Done
       }


### PR DESCRIPTION
### Motivation
Several typos were found in config files, source code, docs, and test resources.

### Modification
Fixed typos: `ammount`→`amount`, `setttings`→`settings`, `transacitonal`→`transactional`, `preceeding`→`preceding`, `levle`→`level` in reference.conf, ConsumerResetProtection, TransactionalProducerStage, CommitCollectorStageSpec, transactions.md, and logback-test.xml.

### Result
Cleaner codebase with corrected spelling.

### Tests
Not run - typo fixes only (comments, strings, config, docs)

### References
None - typo cleanup