### PR TITLE
refactor: modernize Java test code with Java 17 records

### DIFF
--- a/java-tests/src/test/java/docs/javadsl/ClusterShardingExample.java
+++ b/java-tests/src/test/java/docs/javadsl/ClusterShardingExample.java
@@ -39,15 +39,7 @@ import org.apache.pekko.stream.javadsl.Sink;
 public class ClusterShardingExample {
 
   // #user-entity
-  static final class User {
-    public final String id;
-    public final String mame;
-
-    User(String id, String mame) {
-      this.id = id;
-      this.mame = mame;
-    }
-  }
+  record User(String id, String mame) {}
 
   // #user-entity
 
@@ -70,7 +62,7 @@ public class ClusterShardingExample {
             .messageExtractorNoEnvelope(
                 "user-topic",
                 Duration.ofSeconds(10),
-                (User msg) -> msg.id,
+                (User msg) -> msg.id(),
                 ConsumerSettings.create(
                     Adapter.toClassic(system), new StringDeserializer(), new StringDeserializer()));
     // #message-extractor

--- a/java-tests/src/test/java/docs/javadsl/SampleData.java
+++ b/java-tests/src/test/java/docs/javadsl/SampleData.java
@@ -14,36 +14,11 @@
 
 package docs.javadsl;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Objects;
 
-public class SampleData {
-
-  public final String name;
-  public final int value;
-
-  @JsonCreator
-  public SampleData(@JsonProperty("name") String name, @JsonProperty("value") int value) {
-    this.name = name;
-    this.value = value;
-  }
-
+public record SampleData(@JsonProperty("name") String name, @JsonProperty("value") int value) {
   @Override
   public String toString() {
     return "SampleData(name=" + name + ",value=" + value + ")";
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    SampleData that = (SampleData) o;
-    return value == that.value && Objects.equals(name, that.name);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(name, value);
   }
 }


### PR DESCRIPTION
### Motivation
Java 17 introduced records that make Java code more concise by eliminating boilerplate for data carrier classes.

### Modification
- Convert SampleData class to a Java record with Jackson annotations
- Convert User class to a record in ClusterShardingExample
- Update field accesses to use record accessor methods

### Result
Test Java code is more concise, reducing equals/hashCode/toString boilerplate while maintaining Jackson serialization compatibility.

### Tests
- `sbt "java-tests / Test / compile"` (to be verified by CI)

### References
None - code modernization