### PR TITLE
Add sbt-salad-days to reduce Scaladoc archive size

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,3 +26,6 @@ addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.1")
 addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.7.0")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.10.7")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.7")
+
+// https://eed3si9n.com/reducing-scaladoc-file-size-with-sbt-salad-days/
+addSbtPlugin("com.eed3si9n" % "sbt-salad-days" % "0.1.0")


### PR DESCRIPTION
## Motivation

Scala 3 Scaladoc archives bundle large font files and `inkuire.js` search engine, bloating release artifacts and wasting CI storage and upload time.

## Modification

Add `sbt-salad-days` plugin (0.1.0) to `project/plugins.sbt`. The plugin operates automatically during Scaladoc packaging — strips fonts and scripts from the generated archives without requiring any additional configuration.

## Result

Significantly smaller Scaladoc archives (e.g. ~420KB for minimal docs), reducing storage consumption in CI/release pipelines.

## References

- Blog post: https://eed3si9n.com/reducing-scaladoc-file-size-with-sbt-salad-days/