### PR TITLE
refactor: migrate Arrays.asList and Collections.singleton to Java 9+ factories

### DIFF
--- a/java-tests/src/test/java/docs/javadsl/AssignmentTest.java
+++ b/java-tests/src/test/java/docs/javadsl/AssignmentTest.java
@@ -16,7 +16,6 @@ package docs.javadsl;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
@@ -92,7 +91,7 @@ public class AssignmentTest extends TestcontainersKafkaJunit4Test {
 
   @Test
   public void mustConsumeFromTheSpecifiedTopicPattern() throws Exception {
-    final List<String> topics = Arrays.asList(createTopic(9001), createTopic(9002));
+    final List<String> topics = List.of(createTopic(9001), createTopic(9002));
     final String group = createGroupId();
     final Integer totalMessages = 100;
     final CompletionStage<Done> producerCompletion =

--- a/java-tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
+++ b/java-tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
@@ -25,7 +25,6 @@ import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.*;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -80,7 +79,7 @@ public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
                 msg -> {
                   Envelope<String, String, CommittableOffset> multiMsg =
                       ProducerMessage.multi(
-                          Arrays.asList(
+                          List.of(
                               new ProducerRecord<>(topic2, msg.record().value()),
                               new ProducerRecord<>(topic3, msg.record().value())),
                           msg.committableOffset());
@@ -121,7 +120,7 @@ public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
                 record -> {
                   Envelope<String, String, NotUsed> multiMsg =
                       ProducerMessage.multi(
-                          Arrays.asList(
+                          List.of(
                               new ProducerRecord<>(topic2, record.value()),
                               new ProducerRecord<>(topic3, record.value())));
                   return multiMsg;
@@ -172,7 +171,7 @@ public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
                   if (duplicate(msg.record().value())) {
                     produce =
                         ProducerMessage.multi(
-                            Arrays.asList(
+                            List.of(
                                 new ProducerRecord<>(topic2, msg.record().value()),
                                 new ProducerRecord<>(topic3, msg.record().value())),
                             msg.committableOffset());

--- a/java-tests/src/test/java/docs/javadsl/MetadataClientTest.java
+++ b/java-tests/src/test/java/docs/javadsl/MetadataClientTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -69,7 +68,7 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
     final TopicPartition partition = new TopicPartition(topic1, 0);
     final ConsumerSettings<String, String> consumerSettings =
         consumerDefaults().withGroupId(group1);
-    final Set<TopicPartition> partitions = Collections.singleton(partition);
+    final Set<TopicPartition> partitions = Set.of(partition);
     final MetadataClient metadataClient =
         MetadataClient.create(consumerSettings, timeout, sys, executor);
 
@@ -95,7 +94,7 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
     final TopicPartition nonExistingPartition = new TopicPartition("non-existing topic", 0);
     final ConsumerSettings<String, String> consumerSettings =
         consumerDefaults().withGroupId(group1);
-    final Set<TopicPartition> partitions = Collections.singleton(nonExistingPartition);
+    final Set<TopicPartition> partitions = Set.of(nonExistingPartition);
     final MetadataClient metadataClient =
         MetadataClient.create(consumerSettings, timeout, sys, executor);
 
@@ -139,7 +138,7 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
     produceString(topic1, 10, partition.partition()).toCompletableFuture().join();
 
     final CompletionStage<Map<TopicPartition, Long>> response =
-        metadataClient.getEndOffsets(Collections.singleton(partition));
+        metadataClient.getEndOffsets(Set.of(partition));
     final Map<TopicPartition, Long> endOffsets = response.toCompletableFuture().join();
 
     assertThat(endOffsets.get(partition), is(10L));
@@ -162,7 +161,7 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
         MetadataClient.create(consumerSettings, timeout, sys, executor);
 
     final CompletionStage<Map<TopicPartition, Long>> response =
-        metadataClient.getEndOffsets(Collections.singleton(nonExistingPartition));
+        metadataClient.getEndOffsets(Set.of(nonExistingPartition));
 
     metadataClient.close();
     response.toCompletableFuture().join();

--- a/java-tests/src/test/java/docs/javadsl/ProducerTest.java
+++ b/java-tests/src/test/java/docs/javadsl/ProducerTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import com.typesafe.config.Config;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
@@ -163,7 +162,7 @@ class ProducerTest extends TestcontainersKafkaTest {
     // #multiMessage
     ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> multiMessage =
         ProducerMessage.multi(
-            Arrays.asList(
+            List.of(
                 new ProducerRecord<>("topicName", key, value),
                 new ProducerRecord<>("anotherTopic", key, value)),
             passThrough);

--- a/java-tests/src/test/java/docs/javadsl/SchemaRegistrySerializationTest.java
+++ b/java-tests/src/test/java/docs/javadsl/SchemaRegistrySerializationTest.java
@@ -23,7 +23,6 @@ import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 // #imports
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,7 +109,7 @@ public class SchemaRegistrySerializationTest extends TestcontainersKafkaJunit4Te
             .withBootstrapServers(bootstrapServers());
 
     SampleAvroClass sample = new SampleAvroClass("key", "name");
-    List<SampleAvroClass> samples = Arrays.asList(sample, sample, sample);
+    List<SampleAvroClass> samples = List.of(sample, sample, sample);
     CompletionStage<Done> producerCompletion =
         Source.from(samples)
             .map(n -> new ProducerRecord<String, Object>(topic, n.key(), n))

--- a/java-tests/src/test/java/docs/javadsl/SendProducerTest.java
+++ b/java-tests/src/test/java/docs/javadsl/SendProducerTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isA;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -87,7 +86,7 @@ public class SendProducerTest extends TestcontainersKafkaTest {
     try {
       ProducerMessage.Envelope<String, String, String> envelope =
           ProducerMessage.multi(
-              Arrays.asList(
+              List.of(
                   new ProducerRecord<>(topic, "key", "value1"),
                   new ProducerRecord<>(topic, "key", "value2"),
                   new ProducerRecord<>(topic, "key", "value3")),

--- a/java-tests/src/test/java/docs/javadsl/SerializationTest.java
+++ b/java-tests/src/test/java/docs/javadsl/SerializationTest.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import docs.javadsl.proto.OrderMessages;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.*;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -79,7 +78,7 @@ public class SerializationTest extends TestcontainersKafkaTest {
     ConsumerSettings<String, String> consumerSettings = consumerDefaults().withGroupId(group);
 
     SampleData sample = new SampleData("Viktor", 45);
-    List<SampleData> samples = Arrays.asList(sample, sample, sample);
+    List<SampleData> samples = List.of(sample, sample, sample);
 
     // #jackson-serializer #jackson-deserializer
 
@@ -146,7 +145,7 @@ public class SerializationTest extends TestcontainersKafkaTest {
     final String group = createGroupId();
 
     OrderMessages.Order sample = OrderMessages.Order.newBuilder().setId("789465").build();
-    List<OrderMessages.Order> samples = Arrays.asList(sample, sample, sample);
+    List<OrderMessages.Order> samples = List.of(sample, sample, sample);
 
     // #protobuf-serializer
 

--- a/java-tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
+++ b/java-tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
@@ -43,7 +43,6 @@ import org.apache.pekko.kafka.testkit.ProducerResultFactory;
 import org.apache.pekko.kafka.testkit.javadsl.ConsumerControlFactory;
 // #factories
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -72,7 +71,7 @@ public class TestkitSamplesTest {
 
     // create elements emitted by the mocked Consumer
     List<ConsumerMessage.CommittableMessage<String, String>> elements =
-        Arrays.asList(
+        List.of(
             ConsumerResultFactory.committableMessage(
                 new ConsumerRecord<>(topic, partition, startOffset, "key", "value 1"),
                 ConsumerResultFactory.committableOffset(

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -15,7 +15,6 @@
 package org.apache.pekko.kafka.testkit.javadsl;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -89,7 +88,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
       Serializer<K> keySerializer,
       Serializer<V> valueSerializer,
       Pair<K, V>... messages) {
-    return Source.from(Arrays.asList(messages))
+    return Source.from(List.of(messages))
         .map(pair -> new ProducerRecord<>(topic, pair.first(), pair.second()))
         .runWith(
             Producer.plainSink(producerDefaults(keySerializer, valueSerializer)), materializer);


### PR DESCRIPTION
### Motivation
Java 9+ provides `List.of()` and `Set.of()` factory methods that are more concise and return truly immutable collections.

### Modification
- Replace `Arrays.asList()` with `List.of()` across 8 files
- Replace `Collections.singleton()` with `Set.of()` in MetadataClientTest
- Update imports accordingly

### Result
Cleaner code using Java 17 immutable collection factories. 9 files changed.

### Tests
Not run - compile-only test file changes

### References
None - Java 17 API modernization