### PR TITLE
refactor: replace .collect(Collectors.toList()) with .toList()

### DIFF
--- a/java-tests/src/test/java/docs/javadsl/AssignmentTest.java
+++ b/java-tests/src/test/java/docs/javadsl/AssignmentTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -102,7 +101,7 @@ public class AssignmentTest extends TestcontainersKafkaJunit4Test {
                     ProducerMessage.multi(
                         topics.stream()
                             .map(t -> new ProducerRecord<>(t, 0, DefaultKey(), msg.toString()))
-                            .collect(Collectors.toList())))
+                            .toList()))
             .via(Producer.flexiFlow(producerDefaults()))
             .runWith(Sink.ignore(), sys);
 

--- a/java-tests/src/test/java/docs/javadsl/FetchMetadataTest.java
+++ b/java-tests/src/test/java/docs/javadsl/FetchMetadataTest.java
@@ -26,7 +26,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import org.apache.kafka.common.PartitionInfo;
 
 // #metadata
@@ -85,7 +84,7 @@ public class FetchMetadataTest extends TestcontainersKafkaJunit4Test {
                                       return partitionInfos.stream()
                                           .map(info -> topic + ": " + info.toString());
                                     })
-                                .collect(Collectors.toList())));
+                                .toList())));
 
     // #metadata
     Optional<List<String>> optionalStrings =

--- a/java-tests/src/test/java/docs/javadsl/FetchMetadataTest.java
+++ b/java-tests/src/test/java/docs/javadsl/FetchMetadataTest.java
@@ -84,7 +84,7 @@ public class FetchMetadataTest extends TestcontainersKafkaJunit4Test {
                                       return partitionInfos.stream()
                                           .map(info -> topic + ": " + info.toString());
                                     })
-                                .toList())));
+                                .toList()));
 
     // #metadata
     Optional<List<String>> optionalStrings =

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/KafkaContainerCluster.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/KafkaContainerCluster.java
@@ -147,7 +147,7 @@ public class KafkaContainerCluster implements Startable {
                   }
                   return container;
                 })
-            .collect(Collectors.toList());
+            .toList();
 
     if (useSchemaRegistry) {
       this.schemaRegistry =

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/PekkoConnectorsKafkaContainer.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/PekkoConnectorsKafkaContainer.java
@@ -227,7 +227,7 @@ public class PekkoConnectorsKafkaContainer extends GenericContainer<PekkoConnect
       List<String> internalIps =
           containerInfo.getNetworkSettings().getNetworks().values().stream()
               .map(ContainerNetwork::getIpAddress)
-              .collect(Collectors.toList());
+              .toList();
 
       command += "export KAFKA_ZOOKEEPER_CONNECT='" + zookeeperConnect + "'\n";
       command +=


### PR DESCRIPTION
### Motivation
Java 16+ `Stream.toList()` provides a concise way to collect stream elements into an unmodifiable list.

### Modification
Replace `.collect(Collectors.toList())` with `.toList()` across 4 files. Remove unused `Collectors` imports.

### Result
Cleaner stream collection code using Java 17 API.

### Tests
Not run - compile-only test file changes

### References
None - Java 17 API modernization