### PR TITLE
refactor: migrate String.format to String.formatted (Java 15+)

### DIFF
--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/KafkaContainerCluster.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/KafkaContainerCluster.java
@@ -184,7 +184,7 @@ public class KafkaContainerCluster implements Startable {
 
   public String getInternalNetworkBootstrapServers() {
     return IntStream.range(0, this.brokersNum)
-        .mapToObj(brokerNum -> String.format("broker-%s:%s", brokerNum, "9092"))
+        .mapToObj(brokerNum -> "broker-%s:%s".formatted(brokerNum, "9092"))
         .collect(Collectors.joining(","));
   }
 

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/PekkoConnectorsKafkaContainer.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/PekkoConnectorsKafkaContainer.java
@@ -170,7 +170,7 @@ public class PekkoConnectorsKafkaContainer extends GenericContainer<PekkoConnect
     if (port == PORT_NOT_ASSIGNED) {
       throw new IllegalStateException("You should start Kafka container first");
     }
-    return String.format("PLAINTEXT://%s:%s", getHost(), port);
+    return "PLAINTEXT://%s:%s".formatted(getHost(), port);
   }
 
   public String getJmxServiceUrl() {
@@ -178,7 +178,7 @@ public class PekkoConnectorsKafkaContainer extends GenericContainer<PekkoConnect
       throw new IllegalStateException("You should start Kafka container first");
     }
 
-    return String.format("service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi", getHost(), jmxPort);
+    return "service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi".formatted(getHost(), jmxPort);
   }
 
   @Override

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/SchemaRegistryContainer.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/SchemaRegistryContainer.java
@@ -48,6 +48,6 @@ public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryCont
   }
 
   public String getSchemaRegistryUrl() {
-    return String.format("http://%s:%s", getHost(), getMappedPort(SCHEMA_REGISTRY_PORT));
+    return "http://%s:%s".formatted(getHost(), getMappedPort(SCHEMA_REGISTRY_PORT));
   }
 }


### PR DESCRIPTION
## Summary
- Migrate `String.format("literal", args)` to `"literal".formatted(args)` (Java 15+ API)
- 3 files updated: Kafka testkit container classes (KafkaContainerCluster, PekkoConnectorsKafkaContainer, SchemaRegistryContainer)
- Behavior-preserving refactoring, no functional changes

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17