### PR TITLE
refactor: migrate JUnit 4 tests to JUnit 6.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@
 
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 import com.github.pjfanning.pekkobuild._
+import com.github.sbt.junit.jupiter.sbt.Import.JupiterKeys
 import com.typesafe.tools.mima.core.{ Problem, ProblemFilters }
 import ProjectSettings.commonSettings
 
@@ -17,6 +18,8 @@ sourceDistIncubating := false
 
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
+ThisBuild / JupiterKeys.junitJupiterVersion := "6.1.0"
+ThisBuild / JupiterKeys.junitPlatformVersion := "6.1.0"
 
 addCommandAlias("checkCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll; +headerCheckAll")
 addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")
@@ -62,7 +65,6 @@ lazy val testkit = project
   .settings(
     name := "pekko-connectors-kafka-testkit",
     AutomaticModuleName.settings("org.apache.pekko.kafka.testkit"),
-    JupiterKeys.junitJupiterVersion := "6.1.0",
     libraryDependencies ++= Dependencies.testKitDependencies,
     libraryDependencies ++= Seq(
       "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value % Provided),

--- a/java-tests/src/test/java/docs/javadsl/AssignmentTest.java
+++ b/java-tests/src/test/java/docs/javadsl/AssignmentTest.java
@@ -14,7 +14,7 @@
 
 package docs.javadsl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -32,36 +32,37 @@ import org.apache.pekko.kafka.Subscriptions;
 import org.apache.pekko.kafka.javadsl.Consumer;
 // #testkit
 import org.apache.pekko.kafka.javadsl.Producer;
-import org.apache.pekko.kafka.testkit.TestcontainersKafkaJunit4Test;
+import org.apache.pekko.kafka.testkit.TestcontainersKafkaTest;
 // #testkit
-import org.apache.pekko.kafka.tests.javadsl.LogCapturingJunit4;
+import org.apache.pekko.kafka.tests.javadsl.LogCapturingExtension;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 // #testkit
 import org.apache.pekko.testkit.javadsl.TestKit;
 // #testkit
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 // #testkit
 
 // #testkit
 
-public class AssignmentTest extends TestcontainersKafkaJunit4Test {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(LogCapturingExtension.class)
+class AssignmentTest extends TestcontainersKafkaTest {
 
   private static final ActorSystem sys = ActorSystem.create("AssignmentTest");
 
-  public AssignmentTest() {
+  AssignmentTest() {
     super(sys);
   }
 
   // #testkit
 
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
-
   @Test
-  public void mustConsumeFromTheSpecifiedSingleTopic() throws Exception {
+  void mustConsumeFromTheSpecifiedSingleTopic() throws Exception {
     final String topic = createTopic();
     final String group = createGroupId();
     final Integer totalMessages = 100;
@@ -89,7 +90,7 @@ public class AssignmentTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void mustConsumeFromTheSpecifiedTopicPattern() throws Exception {
+  void mustConsumeFromTheSpecifiedTopicPattern() throws Exception {
     final List<String> topics = List.of(createTopic(9001), createTopic(9002));
     final String group = createGroupId();
     final Integer totalMessages = 100;
@@ -121,7 +122,7 @@ public class AssignmentTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void mustConsumeFromTheSpecifiedPartition() throws Exception {
+  void mustConsumeFromTheSpecifiedPartition() throws Exception {
     final String topic = createTopic(2, 2);
     final Integer totalMessages = 100;
     final CompletionStage<Done> producerCompletion =
@@ -153,7 +154,7 @@ public class AssignmentTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void mustConsumeFromTheSpecifiedPartitionAndOffset() throws Exception {
+  void mustConsumeFromTheSpecifiedPartitionAndOffset() throws Exception {
     final String topic = createTopic(3);
     final Integer totalMessages = 100;
     final CompletionStage<Done> producerCompletion =
@@ -179,7 +180,7 @@ public class AssignmentTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void mustConsumeFromTheSpecifiedPartitionAndTimestamp() throws Exception {
+  void mustConsumeFromTheSpecifiedPartitionAndTimestamp() throws Exception {
     final String topic = createTopic(4);
     final Integer totalMessages = 100;
     final CompletionStage<Done> producerCompletion =
@@ -214,8 +215,8 @@ public class AssignmentTest extends TestcontainersKafkaJunit4Test {
   }
 
   // #testkit
-  @AfterClass
-  public static void afterClass() {
+  @AfterAll
+  void afterClass() {
     TestKit.shutdownActorSystem(sys);
   }
 }

--- a/java-tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
+++ b/java-tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
@@ -16,7 +16,7 @@ package docs.javadsl;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.typesafe.config.Config;
 import java.time.Duration;

--- a/java-tests/src/test/java/docs/javadsl/FetchMetadataTest.java
+++ b/java-tests/src/test/java/docs/javadsl/FetchMetadataTest.java
@@ -19,8 +19,8 @@ import org.apache.pekko.actor.ActorRef;
 import org.apache.pekko.kafka.ConsumerSettings;
 import org.apache.pekko.kafka.KafkaConsumerActor;
 import org.apache.pekko.kafka.Metadata;
-import org.apache.pekko.kafka.testkit.TestcontainersKafkaJunit4Test;
-import org.apache.pekko.kafka.tests.javadsl.LogCapturingJunit4;
+import org.apache.pekko.kafka.testkit.TestcontainersKafkaTest;
+import org.apache.pekko.kafka.tests.javadsl.LogCapturingExtension;
 import org.apache.pekko.pattern.Patterns;
 import java.time.Duration;
 import java.util.List;
@@ -32,29 +32,30 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.pekko.actor.ActorSystem;
 import java.util.concurrent.TimeUnit;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class FetchMetadataTest extends TestcontainersKafkaJunit4Test {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(LogCapturingExtension.class)
+class FetchMetadataTest extends TestcontainersKafkaTest {
 
   private static final ActorSystem sys = ActorSystem.create("FetchMetadataTest");
 
-  public FetchMetadataTest() {
+  FetchMetadataTest() {
     super(sys);
   }
 
-  @AfterClass
-  public static void afterClass() {
+  @AfterAll
+  void afterClass() {
     TestKit.shutdownActorSystem(sys);
   }
 
   @Test
-  public void demo() throws Exception {
+  void demo() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
         consumerDefaults().withGroupId(createGroupId());
     // #metadata

--- a/java-tests/src/test/java/docs/javadsl/MetadataClientTest.java
+++ b/java-tests/src/test/java/docs/javadsl/MetadataClientTest.java
@@ -19,6 +19,8 @@ import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Map;
@@ -33,35 +35,30 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.kafka.ConsumerSettings;
 import org.apache.pekko.kafka.javadsl.MetadataClient;
-import org.apache.pekko.kafka.testkit.TestcontainersKafkaJunit4Test;
-import org.apache.pekko.kafka.tests.javadsl.LogCapturingJunit4;
+import org.apache.pekko.kafka.testkit.TestcontainersKafkaTest;
+import org.apache.pekko.kafka.tests.javadsl.LogCapturingExtension;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.Timeout;
 // #metadataClient
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(LogCapturingExtension.class)
+class MetadataClientTest extends TestcontainersKafkaTest {
 
   private static final ActorSystem sys = ActorSystem.create("MetadataClientTest");
   private static final Executor executor = Executors.newSingleThreadExecutor();
   private static final Timeout timeout = new Timeout(1, TimeUnit.SECONDS);
 
-  @SuppressWarnings("deprecation")
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  public MetadataClientTest() {
+  MetadataClientTest() {
     super(sys);
   }
 
   @Test
-  public void shouldFetchBeginningOffsetsForGivenPartitions() {
+  void shouldFetchBeginningOffsetsForGivenPartitions() {
     final String topic1 = createTopic();
     final String group1 = createGroupId();
     // #metadataClient
@@ -85,11 +82,7 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void shouldFailInCaseOfAnExceptionDuringFetchBeginningOffsetsForNonExistingTopics() {
-    expectedException.expect(CompletionException.class);
-    expectedException.expectCause(
-        IsInstanceOf.instanceOf(org.apache.kafka.common.errors.InvalidTopicException.class));
-
+  void shouldFailInCaseOfAnExceptionDuringFetchBeginningOffsetsForNonExistingTopics() {
     final String group1 = createGroupId();
     final TopicPartition nonExistingPartition = new TopicPartition("non-existing topic", 0);
     final ConsumerSettings<String, String> consumerSettings =
@@ -103,11 +96,14 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
 
     metadataClient.close();
 
-    response.toCompletableFuture().join();
+    CompletionException exception =
+        assertThrows(CompletionException.class, () -> response.toCompletableFuture().join());
+    assertInstanceOf(
+        org.apache.kafka.common.errors.InvalidTopicException.class, exception.getCause());
   }
 
   @Test
-  public void shouldFetchBeginningOffsetForGivenPartition() {
+  void shouldFetchBeginningOffsetForGivenPartition() {
     final String topic1 = createTopic();
     final String group1 = createGroupId();
     final TopicPartition partition = new TopicPartition(topic1, 0);
@@ -125,7 +121,7 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void shouldFetchEndOffsetsForGivenPartitions() {
+  void shouldFetchEndOffsetsForGivenPartitions() {
     final String topic1 = createTopic();
     final String group1 = createGroupId();
     final TopicPartition partition = new TopicPartition(topic1, 0);
@@ -147,11 +143,7 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void shouldFailInCaseOfAnExceptionDuringFetchEndOffsetsForNonExistingTopic() {
-    expectedException.expect(CompletionException.class);
-    expectedException.expectCause(
-        IsInstanceOf.instanceOf(org.apache.kafka.common.errors.InvalidTopicException.class));
-
+  void shouldFailInCaseOfAnExceptionDuringFetchEndOffsetsForNonExistingTopic() {
     final String group1 = createGroupId();
     final TopicPartition nonExistingPartition = new TopicPartition("non-existing topic", 0);
     final ConsumerSettings<String, String> consumerSettings =
@@ -164,11 +156,15 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
         metadataClient.getEndOffsets(Set.of(nonExistingPartition));
 
     metadataClient.close();
-    response.toCompletableFuture().join();
+
+    CompletionException exception =
+        assertThrows(CompletionException.class, () -> response.toCompletableFuture().join());
+    assertInstanceOf(
+        org.apache.kafka.common.errors.InvalidTopicException.class, exception.getCause());
   }
 
   @Test
-  public void shouldFetchEndOffsetForGivenPartition() {
+  void shouldFetchEndOffsetForGivenPartition() {
     final String topic1 = createTopic();
     final String group1 = createGroupId();
     final TopicPartition partition = new TopicPartition(topic1, 0);
@@ -188,7 +184,7 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void shouldFetchTopicList() {
+  void shouldFetchTopicList() {
     final String group = createGroupId();
     final String topic1 = createTopic(1, 2);
     final String topic2 = createTopic(2, 1);
@@ -216,7 +212,7 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void shouldFetchPartitionsInfoForGivenTopic() {
+  void shouldFetchPartitionsInfoForGivenTopic() {
     final String group = createGroupId();
     final String topic = createTopic(1, 2);
     final ConsumerSettings<String, String> consumerSettings = consumerDefaults().withGroupId(group);
@@ -238,8 +234,8 @@ public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
     metadataClient.close();
   }
 
-  @AfterClass
-  public static void afterClass() {
+  @AfterAll
+  void afterClass() {
     TestKit.shutdownActorSystem(sys);
   }
 }

--- a/java-tests/src/test/java/docs/javadsl/ProducerTest.java
+++ b/java-tests/src/test/java/docs/javadsl/ProducerTest.java
@@ -14,8 +14,8 @@
 
 package docs.javadsl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.typesafe.config.Config;
 import java.util.List;

--- a/java-tests/src/test/java/docs/javadsl/SchemaRegistrySerializationTest.java
+++ b/java-tests/src/test/java/docs/javadsl/SchemaRegistrySerializationTest.java
@@ -47,20 +47,25 @@ import org.apache.pekko.kafka.Subscriptions;
 import org.apache.pekko.kafka.javadsl.Consumer;
 import org.apache.pekko.kafka.javadsl.Producer;
 import org.apache.pekko.kafka.testkit.KafkaTestkitTestcontainersSettings;
-import org.apache.pekko.kafka.testkit.TestcontainersKafkaJunit4Test;
+import org.apache.pekko.kafka.testkit.TestcontainersKafkaTest;
+import org.apache.pekko.kafka.tests.javadsl.LogCapturingExtension;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 // #schema-registry-settings
-public class SchemaRegistrySerializationTest extends TestcontainersKafkaJunit4Test {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(LogCapturingExtension.class)
+class SchemaRegistrySerializationTest extends TestcontainersKafkaTest {
 
   private static final ActorSystem sys = ActorSystem.create("SchemaRegistrySerializationTest");
   private static final Executor ec = Executors.newSingleThreadExecutor();
 
-  public SchemaRegistrySerializationTest() {
+  SchemaRegistrySerializationTest() {
     // #schema-registry-settings
     // NOTE: Overriding KafkaTestkitTestcontainersSettings doesn't necessarily do anything here
     // because the JUnit testcontainer abstract classes run the testcontainers as a singleton.
@@ -77,7 +82,7 @@ public class SchemaRegistrySerializationTest extends TestcontainersKafkaJunit4Te
   // #schema-registry-settings
 
   @Test
-  public void avroDeSerMustWorkWithSchemaRegistry() throws Exception {
+  void avroDeSerMustWorkWithSchemaRegistry() throws Exception {
     final String topic = createTopic();
     final String group = createGroupId();
 
@@ -136,8 +141,8 @@ public class SchemaRegistrySerializationTest extends TestcontainersKafkaJunit4Te
     assertThat(result.size(), is(samples.size()));
   }
 
-  @AfterClass
-  public static void afterClass() {
+  @AfterAll
+  void afterClass() {
     TestKit.shutdownActorSystem(sys);
   }
   // #schema-registry-settings

--- a/java-tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
+++ b/java-tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
@@ -23,16 +23,17 @@ import org.apache.pekko.kafka.ConsumerMessage;
 import org.apache.pekko.kafka.ProducerMessage;
 import org.apache.pekko.kafka.javadsl.Committer;
 import org.apache.pekko.kafka.javadsl.Consumer;
-import org.apache.pekko.kafka.tests.javadsl.LogCapturingJunit4;
+import org.apache.pekko.kafka.tests.javadsl.LogCapturingExtension;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
@@ -47,19 +48,19 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-public class TestkitSamplesTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(LogCapturingExtension.class)
+class TestkitSamplesTest {
 
   private static final ActorSystem sys = ActorSystem.create("TestkitSamplesTest");
 
-  @AfterClass
-  public static void afterClass() {
+  @AfterAll
+  void afterClass() {
     TestKit.shutdownActorSystem(sys);
   }
 
   @Test
-  public void withoutBrokerTesting() throws Exception {
+  void withoutBrokerTesting() throws Exception {
     String topic = "topic";
     String targetTopic = "target-topic";
     String groupId = "group1";

--- a/java-tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
+++ b/java-tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
@@ -14,7 +14,7 @@
 
 package docs.javadsl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.List;
@@ -30,29 +30,30 @@ import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.kafka.*;
 import org.apache.pekko.kafka.javadsl.Consumer;
 import org.apache.pekko.kafka.javadsl.Transactional;
-import org.apache.pekko.kafka.testkit.TestcontainersKafkaJunit4Test;
-import org.apache.pekko.kafka.tests.javadsl.LogCapturingJunit4;
+import org.apache.pekko.kafka.testkit.TestcontainersKafkaTest;
+import org.apache.pekko.kafka.tests.javadsl.LogCapturingExtension;
 import org.apache.pekko.stream.RestartSettings;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(LogCapturingExtension.class)
+class TransactionsExampleTest extends TestcontainersKafkaTest {
 
   private static final ActorSystem system = ActorSystem.create("TransactionsExampleTest");
   private final ExecutorService ec = Executors.newSingleThreadExecutor();
   private final ProducerSettings<String, String> producerSettings = txProducerDefaults();
 
-  public TransactionsExampleTest() {
+  TransactionsExampleTest() {
     super(system);
   }
 
-  @AfterClass
-  public static void afterClass() {
+  @AfterAll
+  void afterClass() {
     TestKit.shutdownActorSystem(system);
   }
 
@@ -70,7 +71,7 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void sourceSink() throws Exception {
+  void sourceSink() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
         consumerDefaults().withGroupId(createGroupId());
     String sourceTopic = createTopic(1);
@@ -106,7 +107,7 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void withOffsetContext() throws Exception {
+  void withOffsetContext() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
         consumerDefaults().withGroupId(createGroupId());
     String sourceTopic = createTopic(1);
@@ -135,7 +136,7 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
   }
 
   @Test
-  public void usingRestartSource() throws Exception {
+  void usingRestartSource() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
         consumerDefaults().withGroupId(createGroupId());
     String sourceTopic = createTopic(1);

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
@@ -27,7 +27,10 @@ import org.junit.Before;
  * unless `stopKafka()` is called.
  *
  * <p>The Testcontainers dependency has to be added explicitly.
+ *
+ * @deprecated Use {@link TestcontainersKafkaTest} instead (JUnit Jupiter/6).
  */
+@Deprecated(since = "2.0.0")
 @SuppressWarnings("unchecked")
 public abstract class TestcontainersKafkaJunit4Test extends KafkaJunit4Test {
 

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/KafkaJunit4Test.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/KafkaJunit4Test.java
@@ -19,7 +19,12 @@ import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.junit.After;
 import org.junit.Before;
 
-/** JUnit 4 base-class with some convenience for accessing a Kafka broker. */
+/**
+ * JUnit 4 base-class with some convenience for accessing a Kafka broker.
+ *
+ * @deprecated Use {@link org.apache.pekko.kafka.testkit.KafkaTest} instead (JUnit Jupiter/6).
+ */
+@Deprecated(since = "2.0.0")
 @SuppressWarnings("unchecked")
 public abstract class KafkaJunit4Test extends BaseKafkaTest {
 


### PR DESCRIPTION
### Motivation
JUnit 4 is end-of-life. JUnit 6 unifies version numbering across Platform, Jupiter, and Vintage components.

### Modification
- Add global JupiterKeys overrides for JUnit Jupiter and Platform 6.1.0
- Migrate Java test files from JUnit 4 to Jupiter
- Replace `ExpectedException` rules with `assertThrows`
- Replace `@Rule LogCapturingJunit4` with `@ExtendWith(LogCapturingExtension.class)`
- Deprecate `KafkaJunit4Test` and `TestcontainersKafkaJunit4Test` (use `KafkaTest`/`TestcontainersKafkaTest` instead)
- Keep JUnit 4 dependency for deprecated testkit classes (binary compatibility)

### Result
All tests run on JUnit 6.1.0. Deprecated JUnit 4 testkit classes remain for backward compatibility.

### Tests
Not run - compilation verification needed with sbt in CI environment

### References
None - JUnit 6 migration