### PR TITLE
fix: fix javadoc warnings in testkit Java sources

### DIFF
--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
@@ -22,9 +22,9 @@ import org.junit.After;
 import org.junit.Before;
 
 /**
- * JUnit 4 base class using <a href="https://www.testcontainers.org/">Testcontainers</a> to start a Kafka
- * broker in a Docker container. The Kafka broker will be kept around across multiple test classes,
- * unless `stopKafka()` is called.
+ * JUnit 4 base class using <a href="https://www.testcontainers.org/">Testcontainers</a> to start a
+ * Kafka broker in a Docker container. The Kafka broker will be kept around across multiple test
+ * classes, unless `stopKafka()` is called.
  *
  * <p>The Testcontainers dependency has to be added explicitly.
  *

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaJunit4Test.java
@@ -22,7 +22,7 @@ import org.junit.After;
 import org.junit.Before;
 
 /**
- * JUnit 4 base class using [[https://www.testcontainers.org/ Testcontainers]] to start a Kafka
+ * JUnit 4 base class using <a href="https://www.testcontainers.org/">Testcontainers</a> to start a Kafka
  * broker in a Docker container. The Kafka broker will be kept around across multiple test classes,
  * unless `stopKafka()` is called.
  *

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaTest.java
@@ -19,7 +19,7 @@ import org.apache.pekko.actor.ClassicActorSystemProvider;
 import org.apache.pekko.kafka.testkit.internal.TestcontainersKafka;
 
 /**
- * JUnit 5 base class using [[https://www.testcontainers.org/ Testcontainers]] to start a Kafka
+ * JUnit 5 base class using <a href="https://www.testcontainers.org/">Testcontainers</a> to start a Kafka
  * broker in a Docker container. The Kafka broker will be kept around across multiple test classes,
  * unless `stopKafka()` is called (eg. from an `@AfterAll`-annotated method.
  *

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/TestcontainersKafkaTest.java
@@ -19,9 +19,9 @@ import org.apache.pekko.actor.ClassicActorSystemProvider;
 import org.apache.pekko.kafka.testkit.internal.TestcontainersKafka;
 
 /**
- * JUnit 5 base class using <a href="https://www.testcontainers.org/">Testcontainers</a> to start a Kafka
- * broker in a Docker container. The Kafka broker will be kept around across multiple test classes,
- * unless `stopKafka()` is called (eg. from an `@AfterAll`-annotated method.
+ * JUnit 5 base class using <a href="https://www.testcontainers.org/">Testcontainers</a> to start a
+ * Kafka broker in a Docker container. The Kafka broker will be kept around across multiple test
+ * classes, unless `stopKafka()` is called (eg. from an `@AfterAll`-annotated method.
  *
  * <p>Extending classes must be annotated with `@TestInstance(Lifecycle.PER_CLASS)` to create a
  * single instance of the test class with `@BeforeAll` and `@AfterAll` annotated methods called by

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -62,9 +62,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
     return log;
   }
 
-  /**
-   * Overwrite to set different default timeout for {@code resultOf}.
-   */
+  /** Overwrite to set different default timeout for {@code resultOf}. */
   protected Duration resultOfTimeout() {
     return Duration.ofSeconds(5);
   }

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -63,8 +63,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
   }
 
   /**
-   * Overwrite to set different default timeout for
-   * [[resultOf[T](stage:java\.util\.concurrent\.CompletionStage[T])* resultOf]].
+   * Overwrite to set different default timeout for {@code resultOf}.
    */
   protected Duration resultOfTimeout() {
     return Duration.ofSeconds(5);


### PR DESCRIPTION
## Motivation

Running `sbt doc` produces javadoc warnings in Java source files of the testkit module:
- Scala-style `[[...]]` links are not recognized by javadoc

## Modification

- `TestcontainersKafkaTest.java`: Replace Scala-style `[[https://www.testcontainers.org/ Testcontainers]]` link with HTML anchor
- `TestcontainersKafkaJunit4Test.java`: Same fix
- `BaseKafkaTest.java`: Replace Scala-style `[[resultOf[T]...]]` method reference with `{@code resultOf}`

## Result

Javadoc warnings are eliminated.

## Tests

Not run - docs only

## References

None