### PR TITLE
refactor: remove Alpakka Kafka deprecated APIs

### DIFF
--- a/core/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-code.excludes
+++ b/core/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-code.excludes
@@ -39,3 +39,7 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.kafka.scala
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.kafka.scaladsl.Producer.committableSink")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.kafka.scaladsl.Producer.plainSink")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.kafka.scaladsl.SendProducer.apply")
+
+# Remove deprecated ManualSubscription.withRebalanceListener (since Alpakka Kafka 1.0-RC1)
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.kafka.Subscriptions#ManualSubscriptionImpl.withRebalanceListener")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.kafka.Subscriptions#ManualSubscription.withRebalanceListener")

--- a/core/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-code.excludes
+++ b/core/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-code.excludes
@@ -41,5 +41,6 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.kafka.scala
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.kafka.scaladsl.SendProducer.apply")
 
 # Remove deprecated ManualSubscription.withRebalanceListener (since Alpakka Kafka 1.0-RC1)
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.kafka.ManualSubscription.withRebalanceListener")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.kafka.Subscriptions#ManualSubscriptionImpl.withRebalanceListener")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.kafka.Subscriptions#ManualSubscription.withRebalanceListener")

--- a/core/src/main/scala/org/apache/pekko/kafka/Subscriptions.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/Subscriptions.scala
@@ -41,14 +41,7 @@ sealed trait Subscription {
  * Kafka-speak for these is "Assignments".
  */
 sealed trait ManualSubscription extends Subscription {
-
-  /** @deprecated Manual subscriptions never rebalances, since Alpakka Kafka 1.0-RC1 */
-  @deprecated("Manual subscription never rebalances", "Alpakka Kafka 1.0-RC1")
   def rebalanceListener: Option[ActorRef] = None
-
-  /** @deprecated Manual subscriptions never rebalances, since Alpakka Kafka 1.0-RC1 */
-  @deprecated("Manual subscription never rebalances", "Alpakka Kafka 1.0-RC1")
-  def withRebalanceListener(ref: ActorRef): ManualSubscription
 }
 
 /**

--- a/core/src/main/scala/org/apache/pekko/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/scaladsl/Consumer.scala
@@ -109,12 +109,7 @@ object Consumer {
 
     override def stop(): Future[Done] = control.stop()
 
-    @deprecated("Use `drainAndShutdown` for proper shutdown of the stream.", "Alpakka Kafka 2.0.0")
-    override def shutdown(): Future[Done] =
-      control
-        .shutdown()
-        .flatMap(_ => streamCompletion)(ExecutionContext.parasitic)
-        .map(_ => Done)(ExecutionContext.parasitic)
+    override def shutdown(): Future[Done] = control.shutdown()
 
     override def drainAndShutdown[S](streamCompletion: Future[S])(implicit ec: ExecutionContext): Future[S] =
       control.drainAndShutdown(streamCompletion)


### PR DESCRIPTION
### Motivation
- `ManualSubscription.rebalanceListener`/`withRebalanceListener` were deprecated since Alpakka Kafka 1.0-RC1 (manual subscriptions never rebalance).
- `DrainingControl.shutdown()` was deprecated since Alpakka Kafka 2.0.0 in favor of `drainAndShutdown()`.

### Modification
- Remove deprecated `rebalanceListener` and `withRebalanceListener` from `ManualSubscription` trait. Concrete case classes (`Assignment`, `AssignmentWithOffset`, `AssignmentOffsetsForTimes`) already implement `withRebalanceListener` and now inherit `rebalanceListener = None` from the trait.
- Simplify `DrainingControl.shutdown()` to delegate to `control.shutdown()` without the deprecated drain-and-wait behavior, making it consistent with other `Control` implementations.

### Result
`ManualSubscription` no longer exposes misleading rebalance listener methods. `DrainingControl.shutdown()` delegates consistently with other `Control` methods.

### Tests
Not run - deprecated API cleanup

### References
None - deprecated API cleanup