### PR TITLE
fix: fix compilation warnings across all Scala versions

### DIFF
--- a/testkit/src/main/scala/org/apache/pekko/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/org/apache/pekko/kafka/testkit/internal/KafkaTestKit.scala
@@ -94,12 +94,6 @@ trait KafkaTestKit {
 
   val settings = KafkaTestkitSettings(system)
 
-  private lazy val adminDefaults: java.util.Map[String, AnyRef] = {
-    val config = new java.util.HashMap[String, AnyRef]()
-    config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
-    config
-  }
-
   private var adminClientVar: Admin = null
 
   /**
@@ -119,7 +113,7 @@ trait KafkaTestKit {
    */
   def setUpAdminClient(): Unit =
     if (adminClientVar == null) {
-      adminClientVar = Admin.create(adminDefaults)
+      adminClientVar = Admin.create(KafkaTestKit.adminDefaultsMap(bootstrapServers))
     }
 
   /**
@@ -196,6 +190,14 @@ trait KafkaTestKit {
   def sleepSeconds(s: Int, msg: String): Unit = {
     log.debug(s"sleeping $s s $msg")
     Thread.sleep(s * 1000L)
+  }
+}
+
+object KafkaTestKit {
+  private[internal] def adminDefaultsMap(bootstrapServers: String): java.util.Map[String, AnyRef] = {
+    val config = new java.util.HashMap[String, AnyRef]()
+    config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+    config
   }
 }
 


### PR DESCRIPTION
### Motivation
Java unchecked conversion warnings when compiling Java test classes that extend `KafkaTestKitClass` (which implements the `KafkaTestKit` trait). The `private lazy val adminDefaults` in the trait generated a mangled accessor method on the interface with an erased return type (`java.util.Map`), causing javac to warn about unchecked conversion to `java.util.Map<String, Object>`. This affected 9 Java test files during Scala 3 cross-compilation.

### Modification
Moved the `adminDefaults` map creation from a `private lazy val` in the `KafkaTestKit` trait to a `private[internal]` method in a new `KafkaTestKit` companion object. This eliminates the mangled interface method that triggered the Java compiler warnings.

### Result
Clean compilation with zero warnings across all Scala versions.

### Tests
- `sbt +test:compile` - all versions pass with no warnings

### References
None - code quality improvement