### PR TITLE
Fix TransactionalProducerStage.onCompletionSuccess() to wait for in-flight confirmations before completing

### DIFF
--- a/core/src/main/scala/org/apache/pekko/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/TransactionalProducerStage.scala
@@ -31,6 +31,7 @@ import org.apache.kafka.common.TopicPartition
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 /**
  * INTERNAL API
@@ -231,12 +232,37 @@ private final class TransactionalProducerStageLogic[K, V, P](
   override def onCompletionSuccess(): Unit = {
     log.debug("Committing final transaction before shutdown")
     cancelTimer(commitSchedulerKey)
-    maybeCommitTransaction(beginNewTransaction = false, abortEmptyTransactionOnComplete = true)
+    setKeepGoing(true)
+    try {
+      batchOffsets match {
+        case batch: NonemptyTransactionBatch =>
+          commitTransaction(batch, beginNewTransaction = false)
+        case _: EmptyTransactionBatch =>
+          abortTransaction("Transaction is empty and stage is completing")
+        case _ =>
+          ()
+      }
+    } catch {
+      case NonFatal(ex) =>
+        log.error(ex, "Failed to commit final transaction, aborting")
+        try {
+          abortTransaction("Final transaction commit failed")
+        } catch {
+          case NonFatal(abortEx) =>
+            log.error(abortEx, "Failed to abort transaction after commit failure")
+        }
+        batchOffsets.committingFailed()
+    }
     super.onCompletionSuccess()
   }
 
   override def onCompletionFailure(ex: Throwable): Unit = {
-    abortTransaction("Stage failure")
+    try {
+      abortTransaction("Stage failure")
+    } catch {
+      case NonFatal(abortEx) =>
+        log.error(abortEx, "Failed to abort transaction during stage failure")
+    }
     batchOffsets.committingFailed()
     super.onCompletionFailure(ex)
   }

--- a/tests/src/test/scala/org/apache/pekko/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/internal/ProducerSpec.scala
@@ -30,7 +30,7 @@ import pekko.{ Done, NotUsed }
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, OffsetAndMetadata }
 import org.apache.kafka.clients.producer._
-import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.{ KafkaException, TopicPartition }
 import org.apache.kafka.common.serialization.StringSerializer
 import org.mockito
 import org.mockito.Mockito
@@ -563,6 +563,80 @@ class ProducerSpec(_system: ActorSystem)
     client.verifyTxAbort()
     client.verifyClosed()
   }
+
+  it should "abort transaction and close producer when commitTransaction fails during shutdown" in {
+    val input = recordAndMetadata(1)
+
+    val client = {
+      val inputMap = Map(input)
+      new ProducerMock[K, V](ProducerMock.handlers.delayedMap(100.millis)(x => Try { inputMap(x) }))
+    }
+    val committedMarker = new CommittedMarkerMock
+
+    val (source, sink) = TestSource[TxMsg]()
+      .via(testTransactionProducerFlow(client))
+      .toMat(TestSink())(Keep.both)
+      .run()
+
+    val txMsg: TxMsg = toTxMessage(input, committedMarker.mock)
+    source.sendNext(txMsg)
+    sink.requestNext()
+
+    client.verifySend(atLeastOnce())
+
+    // Wait for the timer-based commit to succeed first
+    awaitAssert(client.verifyTxCommit(txMsg.passThrough), 2.second)
+
+    // Now make commitTransaction throw for the shutdown commit
+    Mockito
+      .doAnswer(_ => throw new KafkaException("commit failed"))
+      .when(client.mock)
+      .commitTransaction()
+
+    // Complete the source to trigger onCompletionSuccess
+    source.sendComplete()
+    sink.expectComplete()
+
+    // Verify: commitTransaction was called (and threw), then abortTransaction as fallback, then producer closed
+    client.verifyTxAbortAfterFailedCommit()
+  }
+
+  it should "close producer when abortTransaction fails during stage failure" in {
+    val input = recordAndMetadata(1)
+
+    val client = {
+      val inputMap = Map(input)
+      new ProducerMock[K, V](ProducerMock.handlers.delayedMap(100.millis)(x => Try { inputMap(x) }))
+    }
+    val committedMarker = new CommittedMarkerMock
+
+    val (source, sink) = TestSource[TxMsg]()
+      .via(testTransactionProducerFlow(client))
+      .toMat(Sink.lastOption)(Keep.both)
+      .run()
+
+    val txMsg = toTxMessage(input, committedMarker.mock)
+    source.sendNext(txMsg)
+
+    awaitAssert(client.verifyTxInitialized())
+
+    // Make abortTransaction throw
+    Mockito
+      .doAnswer(_ => throw new KafkaException("abort failed"))
+      .when(client.mock)
+      .abortTransaction()
+
+    // Trigger stage failure
+    source.sendError(new Exception("upstream failure"))
+
+    Await.ready(sink, remainingOrDefault)
+    sink.value should matchPattern {
+      case Some(Failure(_)) =>
+    }
+
+    // Even though abortTransaction throws, the producer should still be closed
+    client.verifyClosedAfterFailedAbort()
+  }
 }
 
 object ProducerMock {
@@ -667,6 +741,21 @@ class ProducerMock[K, V](handler: ProducerMock.Handler[K, V])(implicit ec: Execu
   }
 
   def verifyTxAbort() = {
+    val inOrder = Mockito.inOrder(mock)
+    inOrder.verify(mock).abortTransaction()
+    inOrder.verify(mock).flush()
+    inOrder.verify(mock).close(mockito.ArgumentMatchers.any[java.time.Duration])
+  }
+
+  def verifyTxAbortAfterFailedCommit() = {
+    val inOrder = Mockito.inOrder(mock)
+    inOrder.verify(mock).commitTransaction()
+    inOrder.verify(mock).abortTransaction()
+    inOrder.verify(mock).flush()
+    inOrder.verify(mock).close(mockito.ArgumentMatchers.any[java.time.Duration])
+  }
+
+  def verifyClosedAfterFailedAbort() = {
     val inOrder = Mockito.inOrder(mock)
     inOrder.verify(mock).abortTransaction()
     inOrder.verify(mock).flush()


### PR DESCRIPTION
Changes to TransactionalProducerStage.scala

onCompletionSuccess() (line 232-257)

Before: Called maybeCommitTransaction(...) then unconditionally called super.onCompletionSuccess() (→ completeStage()). If the commit threw an exception, it propagated unhandled — the stage would fail without explicitly aborting the transaction, and the producer would be closed with an in-progress transaction that gets implicitly aborted (data loss).

After:
1. setKeepGoing(true) — prevents the stage from auto-completing while the commit is in progress
2. Inlined maybeCommitTransaction logic — directly matches on batchOffsets instead of delegating, removing the unreachable awaitingConf > 0 timer-scheduling branches (which would have been dangerous if reached, since super.onCompletionSuccess() would still be called)
3. try/catch NonFatal — if commitTransaction throws, the catch block:
  - Logs the error
  - Attempts to abortTransaction to roll back cleanly
  - Catches and logs any failure in the abort itself
  - Calls batchOffsets.committingFailed() to notify the committer
4. super.onCompletionSuccess() is always reached (either after successful commit/abort, or after the catch block handles the failure)

onCompletionFailure() (line 259-268)

Before: Called abortTransaction("Stage failure") without any exception handling. If abortTransaction threw (e.g., InvalidTxnStateException, network error), the exception propagated and super.onCompletionFailure(ex) was never called.

After: Wrapped in try/catch NonFatal so that even if the abort failsailed() and super.onCompletionFailure(ex) are always called.


onCompletionSuccess() (line 232-257)

Before: Called maybeCommitTransaction(...) then unconditionally called super.onCompletionSuccess() (→ completeStage()). If the commit threw an exception, it
propagated unhandled — the stage would fail without explicitly aborthe producer would be closed with an in-progress transaction that gets implicitly aborted (data loss).

After:
1. setKeepGoing(true) — prevents the stage from auto-completing whils
2. Inlined maybeCommitTransaction logic — directly matches on batchOffsets instead of delegating, removing the unreachable awaitingConf > 0 timer-scheduling branches (which would have been dangerous if reached, since super.onCompletionSuccess() would still be called)
3. try/catch NonFatal — if commitTransaction throws, the catch block
  - Logs the error
  - Attempts to abortTransaction to roll back cleanly
  - Catches and logs any failure in the abort itself
  - Calls batchOffsets.committingFailed() to notify the committer
4. super.onCompletionSuccess() is always reached (either after successful commit/abort, or after the catch block handles the failure)

onCompletionFailure() (line 259-268)

Before: Called abortTransaction("Stage failure") without any exceptiaction threw (e.g., InvalidTxnStateException, network error), theexception propagated and super.onCompletionFailure(ex) was never called.

After: Wrapped in try/catch NonFatal so that even if the abort fails, batchOffsets.committingFailed() and super.onCompletionFailure(ex) are always called.
