### PR TITLE
propagate KafkaConnectionFailed to owner actor

### DIFF
--- a/core/src/main/scala/org/apache/pekko/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/KafkaConsumerActor.scala
@@ -659,10 +659,11 @@ import scala.util.control.NonFatal
 
   private def processErrors(exception: Throwable): Unit = {
     val sendTo = (stageActorsMap.values ++ owner).toSet
-    log.debug(s"sending failure {} to {}", exception.getClass, sendTo.mkString(","))
+    log.debug("sending failure {} to {}", exception.getClass, sendTo.mkString(","))
     stageActorsMap.values.foreach { stageActorRef =>
       sendFailure(exception, stageActorRef)
     }
+    owner.foreach(_ ! Failure(exception))
   }
 
   private def handleMetadataRequest(req: Metadata.Request): Metadata.Response = req match {

--- a/core/src/main/scala/org/apache/pekko/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/org/apache/pekko/kafka/internal/KafkaConsumerActor.scala
@@ -659,7 +659,8 @@ import scala.util.control.NonFatal
 
   private def processErrors(exception: Throwable): Unit = {
     val sendTo = (stageActorsMap.values ++ owner).toSet
-    log.debug("sending failure {} to {}", exception.getClass, sendTo.mkString(","))
+    if (log.isDebugEnabled)
+      log.debug("sending failure {} to {}", exception.getClass, sendTo.mkString(","))
     stageActorsMap.values.foreach { stageActorRef =>
       sendFailure(exception, stageActorRef)
     }

--- a/tests/src/test/scala/org/apache/pekko/kafka/internal/ConsumerSpec.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/internal/ConsumerSpec.scala
@@ -21,13 +21,17 @@ import pekko.kafka.ConsumerMessage._
 import pekko.kafka.scaladsl.Consumer
 import pekko.kafka.scaladsl.Consumer.Control
 import pekko.kafka.tests.scaladsl.LogCapturing
-import pekko.kafka.{ CommitTimeoutException, ConsumerSettings, Repeated, Subscriptions }
+import pekko.actor.Status.Failure
+import pekko.kafka.{ CommitTimeoutException, ConsumerSettings, KafkaConnectionFailed, Repeated, Subscriptions }
+import pekko.kafka.{ KafkaConsumerActor => PublicKafkaConsumerActor }
+import pekko.testkit.TestProbe
 import pekko.stream.scaladsl._
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import pekko.stream.testkit.scaladsl.TestSink
 import pekko.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.clients.consumer._
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterAll
@@ -334,5 +338,35 @@ class ConsumerSpec(_system: ActorSystem)
     Await.result(done, remainingOrDefault)
     Await.result(control.isShutdown, remainingOrDefault)
     mock.verifyClosed()
+  }
+
+  it should "propagate KafkaConnectionFailed to owner actor" in {
+    val mock = new ConsumerMock[K, V]()
+    val ownerProbe = TestProbe()
+    val settings = ConsumerSettings
+      .create(system, new StringDeserializer, new StringDeserializer)
+      .withGroupId("group1")
+      .withCloseTimeout(ConsumerMock.closeTimeout)
+      .withConsumerFactory(_ => mock.mock)
+    val actor = system.actorOf(PublicKafkaConsumerActor.props(ownerProbe.ref, settings))
+
+    // trigger initialization by subscribing
+    actor ! KafkaConsumerActor.Internal.Subscribe(
+      Set("topic"),
+      new org.apache.pekko.kafka.scaladsl.PartitionAssignmentHandler {
+        override def onAssign(assignment: Set[TopicPartition],
+            restrictedConsumer: org.apache.pekko.kafka.RestrictedConsumer): Unit = ()
+        override def onRevoke(revokedTps: Set[TopicPartition],
+            restrictedConsumer: org.apache.pekko.kafka.RestrictedConsumer): Unit = ()
+        override def onLost(lostTps: Set[TopicPartition],
+            restrictedConsumer: org.apache.pekko.kafka.RestrictedConsumer): Unit = ()
+        override def onStop(currentTps: Set[TopicPartition],
+            restrictedConsumer: org.apache.pekko.kafka.RestrictedConsumer): Unit = ()
+      })
+
+    val kcf = KafkaConnectionFailed(new org.apache.kafka.common.errors.TimeoutException("connection lost"), 3)
+    actor ! kcf
+
+    ownerProbe.expectMsg(Failure(kcf))
   }
 }


### PR DESCRIPTION
Fix (KafkaConsumerActor.scala): Added owner.foreach(_ ! Failure(exception)) to processErrors — the owner now receives failure notifications alongside stage actors.

Test (ConsumerSpec.scala): "propagate KafkaConnectionFailed to owner actor" — creates a consumer actor with a TestProbe as owner, sends KafkaConnectionFailed, verifies the probe receives the Failure.